### PR TITLE
Build Dimension project intelligence MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 coverage
 *.local
 .envrc
+.dev-ports.env
 
 /cypress/videos/
 /cypress/screenshots/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Dimension
 
-A dream of a visual code editor.
+A project intelligence workspace for humans and AI agents.
 
-This template should help get you started developing with Vue 3 in Vite.
+Dimension maps source files and project folders into browsable structural layers so you can see what an AI built, judge whether the project is well organized, and ask for focused changes without reading every file by hand.
 
 ## Recommended IDE Setup
 
@@ -11,6 +11,21 @@ This template should help get you started developing with Vue 3 in Vite.
 ## Customize configuration
 
 See [Vite Configuration Reference](https://vitejs.dev/config/).
+
+## Development
+
+The project uses the checked-in Docker Compose wrapper. `bin/dev up` writes random free host ports to `.dev-ports.env` and reuses them until the file is removed.
+
+```sh
+./bin/dev up
+./bin/dev down
+```
+
+PlantUML is behind the `design` Compose profile:
+
+```sh
+COMPOSE_PROFILES=design ./bin/dev up
+```
 
 ## Project Setup
 

--- a/agents/plans/Plan, Dimension Future Progress, 2026-06-28.md
+++ b/agents/plans/Plan, Dimension Future Progress, 2026-06-28.md
@@ -12,12 +12,12 @@ Investigate the Dimension project, produce a concrete plan in the project agent-
 - The future-progress plan is a spec-first plan artifact under `agents/plans/`.
 - The plan names the current project state, chosen direction, risks, verification, and execution slices.
 - The first implementation slices are small enough to commit independently.
-- The roadmap moves Dimension from static fixture canvas to source-backed visual code workspace.
+- The roadmap moves Dimension from static fixture canvas to source-backed visual code workspace, and no current framework choice is sacred if a better tool serves that goal.
 
 ### Non-Goals
 
 - Do not build the full editor in this first slice.
-- Do not introduce Canvas or WebGL before SVG rendering has measured pressure.
+- Do not introduce Canvas or WebGL rendering before Scalable Vector Graphics rendering has measured pressure.
 - Do not implement source-code mutation, drag/drop editing, or runtime execution controls yet.
 - Do not preserve the confusing `agents/global-rules/agents/` path as a second source of truth.
 - Do not copy or document committed credential values.
@@ -26,7 +26,7 @@ Investigate the Dimension project, produce a concrete plan in the project agent-
 
 - Keep imported global-rule documents under `agents/global-rules/` unless a later cleanup intentionally removes that snapshot.
 - Keep reusable agent material under `agents/` following the WRAP layout.
-- Use existing stack decisions from `docs/framework-decisions.md`: Vue 3, Vite, TypeScript, D3, SVG-first rendering, Express 5, multer, and `ts-morph`.
+- Use `docs/framework-decisions.md` as the current tool decision record: TypeScript stays central, Vue remains the browser shell, a custom Dimension workspace kernel is the first interaction approach, D3 supports geometry, Scalable Vector Graphics remains the first renderer, and Express with `ts-morph` remains acceptable for source import.
 - Treat package-local build failures as current-state signal until dependency ownership and installation are fixed.
 - Use atomic commits: one logical change per commit.
 
@@ -61,7 +61,7 @@ Investigate the Dimension project, produce a concrete plan in the project agent-
   - `POST /graphs` accepts one uploaded `file` field.
   - `api/src/services/graphs/create-service.ts` parses classes, methods, variable statements, returns, and catch clauses.
 - Current graph models do not line up:
-  - API emits `DimGraph` with `nodes` and `links`.
+  - The API emits `DimGraph` with `nodes` and `links`.
   - Web fixture renders `SpellDiagram` with positioned runes, edge kinds, rings, radii, title, and subtitle.
 - Current tooling is uneven:
   - `web/package.json` has build, type-check, lint, and format scripts.
@@ -79,14 +79,14 @@ Investigate the Dimension project, produce a concrete plan in the project agent-
 
 ### Design Summary
 
-Dimension should use WRAP's agent-data layout and plan shape as the project convention. Agent-facing project material belongs directly under `agents/`, while imported global-rule snapshots may remain under `agents/global-rules/` only as source material. Future progress should then move through a source-backed read-only graph milestone before attempting full editor behavior.
+Dimension should use WRAP's agent-data layout and plan shape as the project convention. Agent-facing project material belongs directly under `agents/`, while imported global-rule snapshots may remain under `agents/global-rules/` only as source material. Future product progress should move through a source-backed read-only graph milestone, but the browser framework and interaction shell should be chosen by fit rather than by the current starter application.
 
 ### Behavior
 
 - Agents looking for project plans read `agents/plans/README.md`, then specific plan files under `agents/plans/`.
 - Agents looking for reusable procedures read `agents/workflows/README.md`, then specific workflow files under `agents/workflows/`.
 - Agents looking for templates or references use `agents/templates/` and `agents/references/`.
-- The Dimension product path moves from fixture-only SVG to imported TypeScript source rendered through a shared graph contract.
+- The Dimension product path moves from fixture-only Scalable Vector Graphics to imported TypeScript source rendered through a shared graph contract.
 - The first UI milestone remains read-only: upload or sample source in, spell diagram out.
 
 ### Interfaces and Data
@@ -99,7 +99,7 @@ Dimension should use WRAP's agent-data layout and plan shape as the project conv
 - Product graph stages:
   - `TypeScript source -> SourceGraph`
   - `SourceGraph -> SpellDiagram`
-  - `SpellDiagram -> SVG`
+  - `SpellDiagram -> Scalable Vector Graphics`
 - Current API route to evolve:
   - `POST /graphs`
 - Current frontend renderer to evolve:
@@ -110,7 +110,7 @@ Dimension should use WRAP's agent-data layout and plan shape as the project conv
 - Moving agent files can break relative links if any documents still point through `agents/global-rules/agents/`.
 - Keeping `agents/global-rules/` as an imported snapshot avoids deleting useful source material but can still confuse readers if docs do not distinguish imported rules from project-local agent data.
 - Fixing local `node_modules` ownership is necessary for builds, but that state should not be committed.
-- The API and web graph contracts are currently divergent; adding UI on top of the mismatch would create adapter churn.
+- The API and browser graph contracts are currently divergent; adding UI on top of the mismatch would create adapter churn.
 
 ## Open Questions
 
@@ -123,7 +123,8 @@ Dimension should use WRAP's agent-data layout and plan shape as the project conv
 - Use WRAP's flat `agents/` structure for project-local agent data.
 - Use WRAP's spec-first plan shape for new Dimension plans.
 - Keep the first product milestone read-only and source-backed.
-- Keep SVG + D3 as the renderer path per `docs/framework-decisions.md`.
+- Treat the browser framework as changeable, but keep Vue for now because the user prefers it and the better first bet is a small custom workspace kernel rather than a React migration.
+- Keep Scalable Vector Graphics and D3 as the renderer path per `docs/framework-decisions.md`.
 - Treat local token exposure as a security cleanup item; never reproduce its value in docs, commits, or plan text.
 
 ## Verification
@@ -140,26 +141,26 @@ Dimension should use WRAP's agent-data layout and plan shape as the project conv
 
 ### Current Branch State
 
-- **Committed:** `224875e` flattens project-local agent material into `agents/`; `f178152` documents spec-first agent plans and WRAP-style discovery READMEs.
+- **Committed:** `224875e` flattens project-local agent material into `agents/`; `f178152` documents spec-first agent plans and WRAP-style discovery READMEs; `123a0e0` keeps local direnv secrets out of versioned setup.
 - **Staged:** Nothing should be staged before each atomic commit is prepared.
-- **Unstaged / Untracked:** The current intended slice removes the committed `.envrc.example`, keeps the project `.envrc` ignore rule, and updates plan wording so no env example or credential placeholder is exposed.
+- **Unstaged / Untracked:** The current intended slice adds a durable Dimension feature list and records a tool-selection direction that keeps Vue while building a custom Dimension workspace kernel first.
 
 ### Remaining Slices
 
-1. Clean secret-bearing environment docs.
-   - Keep `.envrc` ignored for local secrets.
-   - Do not commit `.envrc` examples or credential placeholders.
-2. Stabilize package-local checks.
+1. Stabilize package-local checks.
    - Fix frontend type-check errors.
    - Repair local dependency ownership outside versioned files.
-   - Add missing API check scripts if needed.
+2. Build the custom Vue workspace kernel.
+   - Split the current `SpellCanvas` into graph data, layout helpers, viewport state, glyph rendering, edge rendering, and inspector state.
+   - Add pan, zoom, selection, and keyboard-focusable Scalable Vector Graphics elements.
+   - Compare against Vue Flow only if custom interaction work starts dominating the source-backed editor milestone.
 3. Define the shared graph contract.
    - Add source graph and visual graph types.
    - Add a named layout/transform step between parser and renderer.
-4. Connect import to read-only rendering.
-   - Call `POST /graphs` from the web app.
+4. Connect source import to read-only rendering.
+   - Call `POST /graphs` from the browser application.
    - Render returned visual graph.
-   - Keep sample fixture as a demo path.
+   - Keep sample fixture as a demonstration path.
 
 ## Files to Review
 
@@ -168,10 +169,11 @@ Dimension should use WRAP's agent-data layout and plan shape as the project conv
 3. `agents/plans/Plan, Dimension Future Progress, 2026-06-28.md` - This plan.
 4. `agents/global-rules/` - Imported source snapshot that should not contain another `agents/` directory after flattening.
 5. `.gitignore` - Ensures `.envrc` stays local and unversioned.
-6. `docs/framework-decisions.md` - Existing stack and rendering decisions.
-7. `web/src/components/SpellCanvas.vue` - Current SVG renderer.
-8. `web/src/fixtures/usersControllerIndex.ts` - Current visual graph fixture.
-9. `api/src/services/graphs/create-service.ts` - Current TypeScript source parser seed.
+6. `docs/framework-decisions.md` - Existing and proposed stack decisions.
+7. `docs/dimension-feature-list.md` - Product feature list, including visual code quality signals.
+8. `web/src/components/SpellCanvas.vue` - Current Scalable Vector Graphics renderer.
+9. `web/src/fixtures/usersControllerIndex.ts` - Current visual graph fixture.
+10. `api/src/services/graphs/create-service.ts` - Current TypeScript source parser seed.
 
 ## Related Issues
 

--- a/agents/workflows/feature-workflow.md
+++ b/agents/workflows/feature-workflow.md
@@ -1,0 +1,48 @@
+# Feature Workflow
+
+Use for user-facing feature work that should move through an issue, branch, pull request, review, release, and verification path.
+
+## Intent
+
+**WHY this workflow exists:** Feature work should leave an auditable trail from user story through release instead of disappearing into an unlinked local change.
+
+**WHAT this workflow produces:** A linked issue, branch, PR, reviewed diff, targeted verification, and release/install evidence when the project publishes an artifact.
+
+**Decision Rules:**
+
+- Project-local release and contribution docs win over this generic workflow.
+- Create or update a GitHub issue before coding user-facing work unless the user explicitly says not to use issues.
+- Keep branches and PRs named for the issue so GitHub links the work automatically.
+- Run the smallest checks that cover the changed behavior; do not substitute broad unrelated test runs for missing targeted checks.
+- Before requesting review or merging, authors must self-review the complete PR diff and record findings and outcome in the PR.
+- Run targeted QA of the user-visible changed behavior and the smallest relevant automated checks; record the exact scenario, observed outcome, and command result in the PR.
+- Keep the PR blocked and do not mark it ready or merge while review feedback, QA, or required checks are unresolved.
+- For published artifacts, merge first, then perform the project’s documented version/changelog/publish/install verification steps on the release branch.
+- Do not claim a publish, deploy, marketplace update, or install succeeded unless a command or remote source confirms it.
+
+## Process
+
+1. Capture the user story and acceptance criteria in a GitHub issue.
+2. Record learner coverage for issues that are not clearly learner-authored.
+3. Create a branch named for the issue number and short feature slug.
+4. Implement the feature against project-local patterns and keep the diff scoped to the story.
+5. Open a draft pull request linked to the issue.
+6. Self-review the complete PR diff; record findings, any fixups, and a `PASS`/`FAIL`/`BLOCKED` outcome in the PR.
+7. Run targeted QA for the user-visible changed behavior and the smallest relevant automated checks; record the exact scenario, observed result, and command output in the PR.
+8. Mark the PR ready only after acceptance criteria and current self-review/QA evidence are recorded.
+9. Resolve every actionable review finding. After each fixup, repeat self-review and targeted QA.
+10. Merge through the project's normal PR path only after review and required checks pass.
+11. For published changes, follow the project release docs: version/changelog if required, publish or deploy, poll the remote distribution source until the new version appears, reinstall from the remote source, and verify the installed version.
+
+## Output Contract
+
+Report the concrete artifacts and evidence:
+
+```text
+Issue: <url or number>
+Branch: <branch>
+PR: <url or number>
+Learner coverage: <no action, proposed issue, or filed issue link>
+Verification: <commands or QA path run>
+Release/install: <publish/install/version evidence, or "not published">
+```

--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "test:parser": "node --experimental-strip-types src/services/graphs/create-service.spec.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -4,6 +4,11 @@ import router from "@/router"
 
 export const app = express()
 
+app.use((_request, response, next) => {
+  response.set("Access-Control-Allow-Origin", "*")
+  next()
+})
+
 app.use(router)
 
 export default app

--- a/api/src/controllers/graphs-controller.ts
+++ b/api/src/controllers/graphs-controller.ts
@@ -1,3 +1,4 @@
+import { unlink } from "node:fs/promises"
 import { type Request, type Response } from "express"
 
 import createService from "@/services/graphs/create-service"
@@ -10,11 +11,21 @@ export async function create(req: Request, res: Response): Promise<void> {
     return
   }
 
-  const graph = createService(req.file.path)
+  const uploadPath = req.file.path
 
-  res.json({
-    graph,
-  })
+  try {
+    const graph = createService(uploadPath, req.file.originalname)
+
+    res.json({
+      graph,
+    })
+  } catch {
+    res.status(422).json({
+      message: "The source importer could not parse that file.",
+    })
+  } finally {
+    await unlink(uploadPath).catch(() => undefined)
+  }
 }
 
 export default {

--- a/api/src/services/graphs/create-service.spec.ts
+++ b/api/src/services/graphs/create-service.spec.ts
@@ -8,6 +8,7 @@ import { createService } from "./create-service.ts"
 const directory = await mkdtemp(join(tmpdir(), "dimension-parser-"))
 const typeScriptSourcePath = join(directory, "sample.ts")
 const rubySourcePath = join(directory, "sample.rb")
+const uploadedTypeScriptReactPath = join(directory, "uploaded-typescript-react")
 const uploadedRubyPath = join(directory, "uploaded-ruby")
 
 await writeFile(
@@ -31,6 +32,16 @@ await writeFile(
   const buildWhere = () => {
     const filter = true
     return filter
+  }
+  `,
+)
+
+await writeFile(
+  uploadedTypeScriptReactPath,
+  `function UserBadge() {
+    const label = "ready"
+
+    return <span>{label}</span>
   }
   `,
 )
@@ -67,6 +78,12 @@ try {
       (link) => typeScriptNodeIdentifiers.includes(link.source) && typeScriptNodeIdentifiers.includes(link.target),
     ),
   )
+
+  const typeScriptReactGraph = createService(uploadedTypeScriptReactPath, "sample.tsx")
+  const typeScriptReactNodeIdentifiers = typeScriptReactGraph.nodes.map((node) => node.id)
+
+  assert(typeScriptReactNodeIdentifiers.includes("function:UserBadge"))
+  assert(typeScriptReactNodeIdentifiers.includes("function:UserBadge:local:label"))
 
   const rubyGraph = createService(uploadedRubyPath, "sample.rb")
   const rubyNodeIdentifiers = rubyGraph.nodes.map((node) => node.id)

--- a/api/src/services/graphs/create-service.spec.ts
+++ b/api/src/services/graphs/create-service.spec.ts
@@ -9,6 +9,7 @@ const directory = await mkdtemp(join(tmpdir(), "dimension-parser-"))
 const typeScriptSourcePath = join(directory, "sample.ts")
 const rubySourcePath = join(directory, "sample.rb")
 const uploadedTypeScriptReactPath = join(directory, "uploaded-typescript-react")
+const uploadedCollidingTypeScriptPath = join(directory, "uploaded-colliding-typescript")
 const uploadedRubyPath = join(directory, "uploaded-ruby")
 
 await writeFile(
@@ -42,6 +43,14 @@ await writeFile(
     const label = "ready"
 
     return <span>{label}</span>
+  }
+  `,
+)
+
+await writeFile(
+  uploadedCollidingTypeScriptPath,
+  `function ApiConfig() {
+    return true
   }
   `,
 )
@@ -84,6 +93,11 @@ try {
 
   assert(typeScriptReactNodeIdentifiers.includes("function:UserBadge"))
   assert(typeScriptReactNodeIdentifiers.includes("function:UserBadge:local:label"))
+
+  const collidingTypeScriptGraph = createService(uploadedCollidingTypeScriptPath, "vite.config.ts")
+  const collidingTypeScriptNodeIdentifiers = collidingTypeScriptGraph.nodes.map((node) => node.id)
+
+  assert(collidingTypeScriptNodeIdentifiers.includes("function:ApiConfig"))
 
   const rubyGraph = createService(uploadedRubyPath, "sample.rb")
   const rubyNodeIdentifiers = rubyGraph.nodes.map((node) => node.id)

--- a/api/src/services/graphs/create-service.spec.ts
+++ b/api/src/services/graphs/create-service.spec.ts
@@ -1,0 +1,83 @@
+import { copyFile, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import assert from "node:assert/strict"
+
+import { createService } from "./create-service.ts"
+
+const directory = await mkdtemp(join(tmpdir(), "dimension-parser-"))
+const typeScriptSourcePath = join(directory, "sample.ts")
+const rubySourcePath = join(directory, "sample.rb")
+const uploadedRubyPath = join(directory, "uploaded-ruby")
+
+await writeFile(
+  typeScriptSourcePath,
+  `class UsersController {
+    async index() {
+      const users = await fetchUsers()
+      const names = users.map((user) => {
+        const displayName = user.profile.name
+        return displayName
+      })
+
+      try {
+        return names
+      } catch {
+        return []
+      }
+    }
+  }
+
+  const buildWhere = () => {
+    const filter = true
+    return filter
+  }
+  `,
+)
+
+await writeFile(
+  rubySourcePath,
+  `class UsersController
+    def index
+      users = User.all
+      names = users.map(&:name)
+      render json: names
+    rescue StandardError
+      raise
+    end
+  end
+  `,
+)
+
+await copyFile(rubySourcePath, uploadedRubyPath)
+
+try {
+  const typeScriptGraph = createService(typeScriptSourcePath)
+  const typeScriptNodeIdentifiers = typeScriptGraph.nodes.map((node) => node.id)
+
+  assert(typeScriptNodeIdentifiers.includes("class:UsersController"))
+  assert(typeScriptNodeIdentifiers.includes("class:UsersController:method:index"))
+  assert(typeScriptNodeIdentifiers.includes("class:UsersController:method:index:local:users"))
+  assert(typeScriptNodeIdentifiers.includes("class:UsersController:method:index:return:0"))
+  assert(typeScriptNodeIdentifiers.includes("class:UsersController:method:index:error:0"))
+  assert(typeScriptNodeIdentifiers.includes("function:buildWhere"))
+  assert(!typeScriptNodeIdentifiers.some((identifier) => identifier.includes("displayName")))
+  assert(
+    typeScriptGraph.links.every(
+      (link) => typeScriptNodeIdentifiers.includes(link.source) && typeScriptNodeIdentifiers.includes(link.target),
+    ),
+  )
+
+  const rubyGraph = createService(uploadedRubyPath, "sample.rb")
+  const rubyNodeIdentifiers = rubyGraph.nodes.map((node) => node.id)
+
+  assert(rubyNodeIdentifiers.includes("ruby:class:UsersController"))
+  assert(rubyNodeIdentifiers.includes("ruby:class:UsersController:method:index"))
+  assert(rubyNodeIdentifiers.includes("ruby:class:UsersController:method:index:local:users"))
+  assert(rubyNodeIdentifiers.includes("ruby:class:UsersController:method:index:local:names"))
+  assert(rubyNodeIdentifiers.includes("ruby:class:UsersController:method:index:response:0"))
+  assert(rubyNodeIdentifiers.includes("ruby:class:UsersController:method:index:error:0"))
+  assert(rubyGraph.links.every((link) => rubyNodeIdentifiers.includes(link.source) && rubyNodeIdentifiers.includes(link.target)))
+} finally {
+  await rm(directory, { recursive: true, force: true })
+}

--- a/api/src/services/graphs/create-service.ts
+++ b/api/src/services/graphs/create-service.ts
@@ -3,6 +3,7 @@ import { extname } from "node:path"
 import {
   Node,
   Project,
+  ScriptKind,
   SyntaxKind,
   type ArrowFunction,
   type FunctionDeclaration,
@@ -31,10 +32,10 @@ type CallableDeclaration = FunctionDeclaration | MethodDeclaration | ArrowFuncti
 type RubyStackFrame = { kind: "class" | "method"; node: SourceNode } | { kind: "block" }
 
 export function createService(path: string, sourceName = path): SourceGraph {
-  return extname(sourceName) === ".rb" ? createRubyGraph(path) : createTypeScriptGraph(path)
+  return extname(sourceName) === ".rb" ? createRubyGraph(path) : createTypeScriptGraph(path, sourceName)
 }
 
-function createTypeScriptGraph(path: string): SourceGraph {
+function createTypeScriptGraph(path: string, sourceName: string): SourceGraph {
   const graph: SourceGraph = { nodes: [], links: [] }
 
   const pushNode = (id: string, label: string, type: string) => {
@@ -48,7 +49,10 @@ function createTypeScriptGraph(path: string): SourceGraph {
       allowJs: true,
     },
   })
-  const sourceFile = project.addSourceFileAtPath(path)
+  const sourceFile =
+    extname(path) === extname(sourceName)
+      ? project.addSourceFileAtPath(path)
+      : project.createSourceFile(sourceName, readFileSync(path, "utf8"), { scriptKind: scriptKindFor(sourceName) })
 
   const inspectCallable = (
     callable: CallableDeclaration,
@@ -262,6 +266,19 @@ function currentRubyMethodNode(stack: RubyStackFrame[]): SourceNode | undefined 
 
 function opensRubyBlock(line: string): boolean {
   return /^(?:if|unless|case|begin|for|while|until)\b/.test(line) || /\bdo(?:\s*\|[^|]*\|)?$/.test(line)
+}
+
+function scriptKindFor(sourceName: string): ScriptKind {
+  switch (extname(sourceName)) {
+    case ".js":
+      return ScriptKind.JS
+    case ".jsx":
+      return ScriptKind.JSX
+    case ".tsx":
+      return ScriptKind.TSX
+    default:
+      return ScriptKind.TS
+  }
 }
 
 function containsAwait(node: TypeScriptNode | undefined): boolean {

--- a/api/src/services/graphs/create-service.ts
+++ b/api/src/services/graphs/create-service.ts
@@ -1,73 +1,289 @@
-import ts, { Project } from "ts-morph"
+import { readFileSync } from "node:fs"
+import { extname } from "node:path"
+import {
+  Node,
+  Project,
+  SyntaxKind,
+  type ArrowFunction,
+  type FunctionDeclaration,
+  type FunctionExpression,
+  type MethodDeclaration,
+  type Node as TypeScriptNode,
+} from "ts-morph"
 
-/** Dimension-style node/edge types (same as canvas file) */
-export interface DimNode {
+export interface SourceNode {
   id: string
   label: string
   type: string
 }
-export interface DimLink {
+
+export interface SourceLink {
   source: string
   target: string
 }
-export interface DimGraph {
-  nodes: DimNode[]
-  links: DimLink[]
+
+export interface SourceGraph {
+  nodes: SourceNode[]
+  links: SourceLink[]
 }
 
-/**
- * Convert a ts-morph SourceFile into a Dimension graph.
- */
-export function createService(path: string): DimGraph {
-  const graph: DimGraph = { nodes: [], links: [] }
+type CallableDeclaration = FunctionDeclaration | MethodDeclaration | ArrowFunction | FunctionExpression
+type RubyStackFrame = { kind: "class" | "method"; node: SourceNode } | { kind: "block" }
+
+export function createService(path: string, sourceName = path): SourceGraph {
+  return extname(sourceName) === ".rb" ? createRubyGraph(path) : createTypeScriptGraph(path)
+}
+
+function createTypeScriptGraph(path: string): SourceGraph {
+  const graph: SourceGraph = { nodes: [], links: [] }
 
   const pushNode = (id: string, label: string, type: string) => {
-    if (!graph.nodes.some((n) => n.id === id)) graph.nodes.push({ id, label, type })
+    if (!graph.nodes.some((node) => node.id === id)) graph.nodes.push({ id, label, type })
   }
-  const pushLink = (s: string, t: string) => graph.links.push({ source: s, target: t })
+
+  const pushLink = (source: string, target: string) => graph.links.push({ source, target })
 
   const project = new Project({
     compilerOptions: {
       allowJs: true,
     },
   })
-  const sf = project.addSourceFileAtPath(path)
-  sf.getClasses().forEach((cls) => {
-    const classIdentifier = cls.getName() ?? "UnknownClass"
-    pushNode(classIdentifier, classIdentifier, "class")
+  const sourceFile = project.addSourceFileAtPath(path)
 
-    cls.getMethods().forEach((method) => {
-      const methodIdentifier = method.getName() ?? "UnknownMethod"
-      pushNode(methodIdentifier, methodIdentifier, "method")
-      pushLink(classIdentifier, methodIdentifier)
+  const inspectCallable = (
+    callable: CallableDeclaration,
+    callableIdentifier: string,
+    callableLabel: string,
+    callableType: string,
+    parentIdentifier?: string,
+  ) => {
+    pushNode(callableIdentifier, callableLabel, callableType)
+    if (parentIdentifier) pushLink(parentIdentifier, callableIdentifier)
 
-      method.getDescendantsOfKind(ts.SyntaxKind.VariableStatement).forEach((vs) => {
-        vs.getDeclarations().forEach((decl) => {
-          const id = decl.getName()
-          const init = decl.getInitializer()
-          const type = init?.getFirstDescendantByKind(ts.SyntaxKind.AwaitExpression)
-            ? "async"
-            : "helper"
-          pushNode(id, id, type)
-          pushLink(methodIdentifier, id)
+    let responseIndex = 0
+    let errorIndex = 0
+    const body = callable.getBody()
+
+    if (!body) return
+
+    visitOwnedNodes(body, (node) => {
+      if (Node.isVariableStatement(node)) {
+        node.getDeclarations().forEach((declaration) => {
+          const localName = declaration.getName()
+          const localIdentifier = `${callableIdentifier}:local:${localName}`
+          const initializer = declaration.getInitializer()
+          const localType = containsAwait(initializer) ? "async" : "helper"
+
+          pushNode(localIdentifier, localName, localType)
+          pushLink(callableIdentifier, localIdentifier)
         })
-      })
+      }
 
-      method.getDescendantsOfKind(ts.SyntaxKind.ReturnStatement).forEach((_, i) => {
-        const rId = `${methodIdentifier}_return_${i}`
-        pushNode(rId, "return", "response")
-        pushLink(methodIdentifier, rId)
-      })
+      if (Node.isReturnStatement(node)) {
+        const responseIdentifier = `${callableIdentifier}:return:${responseIndex}`
+        responseIndex += 1
 
-      method.getDescendantsOfKind(ts.SyntaxKind.CatchClause).forEach((_, i) => {
-        const eId = `${methodIdentifier}_error_${i}`
-        pushNode(eId, "error", "error")
-        pushLink(methodIdentifier, eId)
-      })
+        pushNode(responseIdentifier, "return", "response")
+        pushLink(callableIdentifier, responseIdentifier)
+      }
+
+      if (Node.isCatchClause(node)) {
+        const errorIdentifier = `${callableIdentifier}:error:${errorIndex}`
+        errorIndex += 1
+
+        pushNode(errorIdentifier, "error", "error")
+        pushLink(callableIdentifier, errorIdentifier)
+      }
+    })
+  }
+
+  sourceFile.getClasses().forEach((classDeclaration) => {
+    const className = classDeclaration.getName() ?? "UnknownClass"
+    const classIdentifier = `class:${className}`
+
+    pushNode(classIdentifier, className, "class")
+
+    classDeclaration.getMethods().forEach((methodDeclaration) => {
+      const methodName = methodDeclaration.getName()
+
+      inspectCallable(
+        methodDeclaration,
+        `${classIdentifier}:method:${methodName}`,
+        methodName,
+        "method",
+        classIdentifier,
+      )
+    })
+  })
+
+  sourceFile.getFunctions().forEach((functionDeclaration) => {
+    const functionName = functionDeclaration.getName() ?? "anonymousFunction"
+
+    inspectCallable(functionDeclaration, `function:${functionName}`, functionName, "function")
+  })
+
+  sourceFile.getVariableStatements().forEach((statement) => {
+    statement.getDeclarations().forEach((declaration) => {
+      const initializer = declaration.getInitializer()
+
+      if (!initializer || (!Node.isArrowFunction(initializer) && !Node.isFunctionExpression(initializer))) return
+
+      const functionName = declaration.getName()
+
+      inspectCallable(initializer, `function:${functionName}`, functionName, "function")
     })
   })
 
   return graph
+}
+
+function createRubyGraph(path: string): SourceGraph {
+  const graph: SourceGraph = { nodes: [], links: [] }
+  const stack: RubyStackFrame[] = []
+  const responseCountBySource = new Map<string, number>()
+  const errorCountBySource = new Map<string, number>()
+
+  const pushNode = (node: SourceNode) => {
+    if (!graph.nodes.some((existingNode) => existingNode.id === node.id)) graph.nodes.push(node)
+  }
+
+  const pushLink = (source: string, target: string) => graph.links.push({ source, target })
+
+  readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .forEach((line) => {
+      const trimmedLine = line.trim()
+
+      if (!trimmedLine || trimmedLine.startsWith("#")) return
+
+      if (trimmedLine === "end") {
+        stack.pop()
+        return
+      }
+
+      const parentNode = currentRubyNode(stack)
+      const classMatch = /^(?:class|module)\s+([A-Z][\w:]*)/.exec(trimmedLine)
+
+      if (classMatch) {
+        const className = classMatch[1]
+        const node = { id: `ruby:class:${className}`, label: className, type: "class" }
+
+        pushNode(node)
+        if (parentNode) pushLink(parentNode.id, node.id)
+        stack.push({ kind: "class", node })
+        return
+      }
+
+      const methodMatch = /^def\s+(?:self\.)?([a-zA-Z_]\w*[!?=]?)/.exec(trimmedLine)
+
+      if (methodMatch) {
+        const methodName = methodMatch[1]
+        const node = {
+          id: `${parentNode?.id ?? "ruby"}:method:${methodName}`,
+          label: methodName,
+          type: "method",
+        }
+
+        pushNode(node)
+        if (parentNode) pushLink(parentNode.id, node.id)
+        stack.push({ kind: "method", node })
+        return
+      }
+
+      const methodNode = currentRubyMethodNode(stack)
+
+      if (!methodNode) return
+
+      const localMatch = /^([a-z_]\w*)\s*=/.exec(trimmedLine)
+
+      if (localMatch) {
+        const localName = localMatch[1]
+        const localNode = {
+          id: `${methodNode.id}:local:${localName}`,
+          label: localName,
+          type: "helper",
+        }
+
+        pushNode(localNode)
+        pushLink(methodNode.id, localNode.id)
+      }
+
+      if (/^(return|render|redirect_to|head|json_response)\b/.test(trimmedLine)) {
+        const nextIndex = responseCountBySource.get(methodNode.id) ?? 0
+        const responseNode = {
+          id: `${methodNode.id}:response:${nextIndex}`,
+          label: trimmedLine.split(/\s+/, 1)[0],
+          type: "response",
+        }
+
+        responseCountBySource.set(methodNode.id, nextIndex + 1)
+        pushNode(responseNode)
+        pushLink(methodNode.id, responseNode.id)
+      }
+
+      if (/^(raise|rescue)\b/.test(trimmedLine)) {
+        const nextIndex = errorCountBySource.get(methodNode.id) ?? 0
+        const errorNode = {
+          id: `${methodNode.id}:error:${nextIndex}`,
+          label: trimmedLine.split(/\s+/, 1)[0],
+          type: "error",
+        }
+
+        errorCountBySource.set(methodNode.id, nextIndex + 1)
+        pushNode(errorNode)
+        pushLink(methodNode.id, errorNode.id)
+      }
+
+      if (opensRubyBlock(trimmedLine)) stack.push({ kind: "block" })
+    })
+
+  return graph
+}
+
+function currentRubyNode(stack: RubyStackFrame[]): SourceNode | undefined {
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    const frame = stack[index]
+
+    if (frame.kind !== "block") return frame.node
+  }
+
+  return undefined
+}
+
+function currentRubyMethodNode(stack: RubyStackFrame[]): SourceNode | undefined {
+  for (let index = stack.length - 1; index >= 0; index -= 1) {
+    const frame = stack[index]
+
+    if (frame.kind === "method") return frame.node
+  }
+
+  return undefined
+}
+
+function opensRubyBlock(line: string): boolean {
+  return /^(?:if|unless|case|begin|for|while|until)\b/.test(line) || /\bdo(?:\s*\|[^|]*\|)?$/.test(line)
+}
+
+function containsAwait(node: TypeScriptNode | undefined): boolean {
+  return Boolean(node && (Node.isAwaitExpression(node) || node.getFirstDescendantByKind(SyntaxKind.AwaitExpression)))
+}
+
+function visitOwnedNodes(root: TypeScriptNode, visit: (node: TypeScriptNode) => void): void {
+  root.forEachChild((child) => {
+    if (isCallable(child)) return
+
+    visit(child)
+    visitOwnedNodes(child, visit)
+  })
+}
+
+function isCallable(node: TypeScriptNode): boolean {
+  return (
+    Node.isFunctionDeclaration(node) ||
+    Node.isMethodDeclaration(node) ||
+    Node.isArrowFunction(node) ||
+    Node.isFunctionExpression(node)
+  )
 }
 
 export default createService

--- a/api/src/services/graphs/create-service.ts
+++ b/api/src/services/graphs/create-service.ts
@@ -52,7 +52,9 @@ function createTypeScriptGraph(path: string, sourceName: string): SourceGraph {
   const sourceFile =
     extname(path) === extname(sourceName)
       ? project.addSourceFileAtPath(path)
-      : project.createSourceFile(sourceName, readFileSync(path, "utf8"), { scriptKind: scriptKindFor(sourceName) })
+      : project.createSourceFile(`${path}${extname(sourceName)}`, readFileSync(path, "utf8"), {
+          scriptKind: scriptKindFor(sourceName),
+        })
 
   const inspectCallable = (
     callable: CallableDeclaration,

--- a/api/vite.config.ts
+++ b/api/vite.config.ts
@@ -4,51 +4,16 @@ import { defineConfig } from "vite"
 import { VitePluginNode } from "vite-plugin-node"
 
 export default defineConfig({
-  // ...vite configures
   server: {
-    // vite server configs, for details see [vite doc](https://vitejs.dev/config/#server-host)
     port: 3000,
   },
   plugins: [
     ...VitePluginNode({
-      // Nodejs native Request adapter
-      // currently this plugin support 'express', 'nest', 'koa' and 'fastify' out of box,
-      // you can also pass a function if you are using other frameworks, see Custom Adapter section
       adapter: "express",
-
-      // tell the plugin where is your project entry
-      appPath: "@/app.ts",
-
-      // Optional, default: 'viteNodeApp'
-      // the name of named export of you app from the appPath file
+      appPath: "./src/app.ts",
       exportName: "app",
-
-      // Optional, default: false
-      // if you want to init your app on boot, set this to true
       initAppOnBoot: false,
-
-      // Optional, default: 'esbuild'
-      // The TypeScript compiler you want to use
-      // by default this plugin is using vite default ts compiler which is esbuild
-      // 'swc' compiler is supported to use as well for frameworks
-      // like Nestjs (esbuild dont support 'emitDecoratorMetadata' yet)
-      // you need to INSTALL `@swc/core` as dev dependency if you want to use swc
       tsCompiler: "esbuild",
-
-      // Optional, default: {
-      // jsc: {
-      //   target: 'es2019',
-      //   parser: {
-      //     syntax: 'typescript',
-      //     decorators: true
-      //   },
-      //  transform: {
-      //     legacyDecorator: true,
-      //     decoratorMetadata: true
-      //   }
-      // }
-      // }
-      // swc configs, see [swc doc](https://swc.rs/docs/configuration/swcrc)
       swcOptions: {},
     }),
   ],

--- a/bin/dev
+++ b/bin/dev
@@ -216,11 +216,12 @@ class DevHelper
     raise ScriptError, "Must provide a file path." if file_path.nil?
 
     png_path = file_path.gsub(/\.(wsd|pu|puml|plantuml|uml)$/, ".png")
+    plantuml_port = development_port("DIMENSION_PLANTUML_PORT", "59999")
 
     command = <<~BASH
       curl #{args.join(" ")} \
         --data-binary @'#{file_path}' \
-        http://localhost:9999/png > '#{png_path}'
+        http://localhost:#{plantuml_port}/png > '#{png_path}'
     BASH
 
     puts "Running: #{command}"
@@ -285,6 +286,19 @@ class DevHelper
 
   def port_env_file_path
     "#{project_root}/#{PORT_ENV_FILE}"
+  end
+
+  def development_port(key, fallback)
+    return ENV.fetch(key) if ENV.key?(key)
+
+    if File.exist?(port_env_file_path)
+      File.readlines(port_env_file_path).each do |line|
+        env_key, value = line.strip.split("=", 2)
+        return value if env_key == key && value && !value.empty?
+      end
+    end
+
+    fallback
   end
 
   def compose_project_running?

--- a/bin/dev
+++ b/bin/dev
@@ -2,6 +2,7 @@
 
 require_relative "./github_api"
 require_relative "./pull-request-editor"
+require "socket"
 
 class DevHelper
   # Support dashes in command names
@@ -18,6 +19,14 @@ class DevHelper
 
   REPLACE_PROCESS = "replace_process"
   WAIT_FOR_PROCESS = "wait_for_process"
+
+  PORT_ENV_FILE = ".dev-ports.env"
+  PORT_ENV_KEYS = %w[
+    DIMENSION_API_PORT
+    DIMENSION_API_DEBUG_PORT
+    DIMENSION_WEB_PORT
+    DIMENSION_PLANTUML_PORT
+  ].freeze
 
   # External Interface
   def self.call(*args)
@@ -53,6 +62,7 @@ class DevHelper
   end
 
   def up(*args, **kwargs)
+    ensure_development_ports!
     compose(*%w[up --remove-orphans], *args, **kwargs)
   end
 
@@ -250,11 +260,55 @@ class DevHelper
 
   def compose_command(*args, **kwargs)
     environment = kwargs.fetch(:environment, "development")
-    "cd #{project_root} && docker compose -f docker-compose.#{environment}.yml #{args.join(" ")}"
+    env_file = File.exist?(port_env_file_path) ? "--env-file #{port_env_file_path}" : nil
+    "cd #{project_root} && docker compose #{env_file} -f docker-compose.#{environment}.yml #{args.join(" ")}"
   end
 
   def project_root
     @project_root ||= File.absolute_path("#{__dir__}/..")
+  end
+
+  def ensure_development_ports!
+    return if File.exist?(port_env_file_path) && (compose_project_running? || persisted_development_ports_available?)
+
+    servers = PORT_ENV_KEYS.map { TCPServer.new("127.0.0.1", 0) }
+    assignments = PORT_ENV_KEYS.zip(servers.map { |server| server.addr[1] })
+
+    File.write(
+      port_env_file_path,
+      assignments.map { |key, port| "#{key}=#{port}" }.join("\n") + "\n",
+    )
+    puts "Wrote random development ports to #{port_env_file_path}"
+  ensure
+    servers&.each(&:close)
+  end
+
+  def port_env_file_path
+    "#{project_root}/#{PORT_ENV_FILE}"
+  end
+
+  def compose_project_running?
+    command = "cd #{project_root} && docker compose --env-file #{port_env_file_path} -f docker-compose.development.yml ps -q --status=running"
+
+    !`#{command}`.strip.empty?
+  end
+
+  def persisted_development_ports_available?
+    ports = File.readlines(port_env_file_path).filter_map do |line|
+      key, value = line.strip.split("=", 2)
+      value.to_i if PORT_ENV_KEYS.include?(key)
+    end
+
+    ports.length == PORT_ENV_KEYS.length && ports.uniq.length == ports.length && ports.all? { |port| port_available?(port) }
+  end
+
+  def port_available?(port)
+    server = TCPServer.new("127.0.0.1", port)
+    true
+  rescue Errno::EADDRINUSE
+    false
+  ensure
+    server&.close
   end
 
   def take_over_needed?(file_or_directory)

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -13,8 +13,8 @@ services:
     tty: true # allows attaching debugger, equivalent of docker exec -t
     # stdin_open: true # equivalent of docker exec -i
     ports:
-      - "3000:3000"
-      - "9229:9229"
+      - "${DIMENSION_API_PORT:-57519}:3000"
+      - "${DIMENSION_API_DEBUG_PORT:-59229}:9229"
     volumes:
       - ./api:/usr/src/api
       - ./.gitignore:/usr/src/.gitignore
@@ -26,8 +26,9 @@ services:
       dockerfile: development.Dockerfile
     environment:
       <<: *default-environment
+      DIMENSION_API_INTERNAL_ORIGIN: http://api:3000
     ports:
-      - "8080:8080"
+      - "${DIMENSION_WEB_PORT:-58501}:5173"
     volumes:
       - ./web:/usr/src/web
       - ./.gitignore:/usr/src/.gitignore
@@ -41,7 +42,7 @@ services:
   plantuml:
     image: plantuml/plantuml-server:jetty
     ports:
-      - 9999:8080
+      - "${DIMENSION_PLANTUML_PORT:-59999}:8080"
     environment:
       PLANTUML_LIMIT_SIZE: 8192
     profiles:

--- a/docs/dimension-feature-list.md
+++ b/docs/dimension-feature-list.md
@@ -1,0 +1,167 @@
+# Dimension Feature List
+
+Dimension is a browser-first visual code editor concept. The first product target is a minimum viable product that helps a developer understand a codebase spatially, with a paint-program feeling and a block-based data view style.
+
+## Feature Status Key
+
+- **Now:** belongs in the first minimum viable product path.
+- **Next:** likely follows after the first source-backed visual workspace works.
+- **Later:** useful, but should not steer the first implementation.
+
+## Now
+
+### Source-backed visual workspace
+
+Import a TypeScript source file and render a read-only visual graph from real code structure.
+
+Acceptance criteria:
+
+- A user can upload or select a TypeScript file.
+- The application parses classes, methods, variables, return paths, and error paths.
+- The browser renders a visual code map without relying only on a hard-coded fixture.
+- Every rendered edge references an existing rendered node.
+
+### Shared graph contract
+
+Create one contract between the parser and the visual workspace.
+
+Acceptance criteria:
+
+- The server-side parser emits a source graph with stable identifiers and semantic node kinds.
+- The browser transforms the source graph into a visual graph with positions, sizes, rings, and edge kinds.
+- The renderer consumes the visual graph only.
+
+### Custom visual workspace kernel
+
+Provide pan, zoom, selection, and spatial movement patterns through Dimension-owned Vue components and composables, with a paint-program feeling instead of a stock node-editor surface.
+
+Acceptance criteria:
+
+- A user can pan and zoom the workspace.
+- A user can select a visual node.
+- Selection updates an inspector panel.
+- The canvas keeps Dimension's parchment, glyph, ring, and leyline visual direction.
+- The workspace behavior is small enough to understand: viewport state, pointer gestures, selection, hit testing, focus, graph layout, and inspector updates.
+
+### Code quality visualization
+
+Visually distinguish healthy code from risky code without pretending the tool can judge everything perfectly.
+
+Acceptance criteria:
+
+- Good code and risky code use distinct visual channels that are still accessible without color alone.
+- The inspector explains why a node was marked healthy, risky, or unknown.
+- Quality markers are based on explicit signals, not hidden opinion.
+- Unknown quality is shown as unknown, not as good.
+
+Initial quality signals:
+
+- Type checking result when available.
+- Linting result when available.
+- Method length.
+- Branching complexity.
+- Number of inputs and outputs.
+- Number of error paths.
+- Missing return path where one is expected.
+- Large dependency fan-in or fan-out.
+- Presence or absence of nearby tests when that can be detected.
+
+Initial visual language:
+
+- Healthy code: calm stroke, stable ring, low visual noise.
+- Risky code: broken ring, warning glyph, rougher texture, stronger contrast.
+- Unknown code: muted neutral ring with inspector explanation.
+- Error path: dedicated error leyline and error glyph.
+
+### Inspector panel
+
+Show details for the selected visual node or edge.
+
+Acceptance criteria:
+
+- The inspector shows the selected node name, kind, source location, and quality signals.
+- The inspector can show source text in a read-only code viewer.
+- The inspector does not expose fake runtime controls before runtime behavior exists.
+
+### Sample codebase path
+
+Keep a built-in sample so the visual workspace can be demonstrated before file import is complete.
+
+Acceptance criteria:
+
+- The sample uses the same visual graph contract as imported source.
+- The sample is clearly labeled as sample data.
+
+## Next
+
+### Multi-file codebase map
+
+Expand from one source file to a small project map.
+
+Acceptance criteria:
+
+- The application can show relationships between files, classes, methods, and imports.
+- A user can move from a high-level codebase map into a class or method view.
+
+### Semantic zoom
+
+Support app-to-controller-to-method-to-helper navigation as semantic levels, not only visual scale.
+
+Acceptance criteria:
+
+- A user can enter a node to see a more detailed view.
+- A user can return to the parent view.
+- Breadcrumbs show the current location.
+
+### Search and filtering
+
+Help users find symbols and hide low-value detail.
+
+Acceptance criteria:
+
+- A user can search for a symbol by name.
+- A user can filter by node kind, quality state, or dependency direction.
+
+### Code quality rules configuration
+
+Allow the user to tune what counts as risky code.
+
+Acceptance criteria:
+
+- Quality rules are visible and editable.
+- Rule changes update the visual state.
+- Rule output remains explainable in the inspector.
+
+## Later
+
+### Source editing
+
+Allow changes to source code from the visual workspace.
+
+Reason to defer:
+
+- Editing requires a stronger source graph, reversible transformations, and conflict handling.
+
+### Collaborative editing
+
+Allow multiple users to inspect or edit the same visual code map.
+
+Reason to defer:
+
+- Collaboration adds identity, synchronization, persistence, and conflict concerns before the core visual language is proven.
+
+### Runtime debugging view
+
+Connect runtime traces to the visual graph.
+
+Reason to defer:
+
+- Runtime data needs instrumentation and a stable graph identity model first.
+
+### Canvas or Web Graphics Library renderer
+
+Move beyond Scalable Vector Graphics only if rendering pressure is measured.
+
+Reason to defer:
+
+- Scalable Vector Graphics keeps glyphs inspectable and easier to style while the visual grammar changes.

--- a/docs/framework-decisions.md
+++ b/docs/framework-decisions.md
@@ -1,24 +1,60 @@
 # Dimension Framework Decisions
 
-## Current decision
+## Current Decision
 
-Dimension should stay on the existing split TypeScript stack and add D3 as the visual-layout layer:
+Dimension should keep Vue as the browser application shell for now and build a small Dimension-specific workspace kernel instead of adopting a large editor framework or switching to React only for library availability.
 
-- **Web app:** Vue 3 + Vite + TypeScript.
-- **Routing:** Vue Router, retained for future editor/workspace routes.
-- **Visualization:** SVG-first rendering driven by D3 layout/shape utilities. Canvas/WebGL remains a later optimization after the glyph grammar and interaction model stabilize.
-- **Interaction:** browser Pointer Events for pen/touch/mouse gestures.
-- **API:** Express 5 + TypeScript.
-- **Source import:** `ts-morph` for converting uploaded TypeScript into Dimension graph data.
+The workspace kernel is not a general-purpose public library at first. It is project code that owns pan, zoom, selection, hit testing, keyboard focus, graph-to-glyph layout, and inspector state for Dimension's visual language. Extract it into a reusable library only after the product proves which abstractions are real.
 
-## Why this stack
+- **Primary language:** TypeScript across browser and server code.
+- **Browser application shell:** Vue 3 and Vite remain the preferred shell because the project already uses them and the user prefers Vue.
+- **Workspace kernel:** Custom Vue composables and rendering components for viewport state, pointer gestures, selection, graph layout, and accessibility.
+- **Custom visual language:** Scalable Vector Graphics first, with D3 used for layout and shape utilities.
+- **Interaction:** browser Pointer Events for pen, touch, and mouse gestures.
+- **Server application:** Express 5 and TypeScript are acceptable for the source-import service.
+- **Source import:** `ts-morph` remains the right first parser for converting uploaded TypeScript into Dimension graph data.
+- **Source viewer:** Monaco Editor is the preferred read-only source inspection companion after the visual graph contract is stable.
+- **Rust and WebAssembly:** Defer until a measured parser, analysis, or layout bottleneck appears. Do not use Rust or WebAssembly for the browser shell.
 
-Vue and Vite are already installed and configured, so replacing them would slow the reboot without proving the visual language. D3 fits the project goal better than a generic diagramming framework because Dimension needs custom topology, ring layouts, scaled links, and data-bound visual states rather than boxed UML nodes.
+## Why This Stack
 
-SVG is the first renderer because it keeps glyphs inspectable, accessible, and easy to style while the grammar changes. Canvas or WebGL should only be introduced when the SVG implementation has measurable rendering pressure.
+Dimension needs a semantic graph workspace with a paint-program feel. Generic node editors are useful references, but Dimension's core interaction is not a stock flowchart. The product needs custom glyphs, rings, leylines, semantic zoom, quality markers, and source-aware inspection.
 
-## Legacy content policy
+Building a small workspace kernel is the better slow solution because the current required primitives are limited: viewport transform, pointer capture, selection state, edge path geometry, node hit boxes, focus management, and inspector updates. Pulling in a full graph editor too early risks fighting its data model and visual defaults.
 
-Remove framework starter/demo content, including Vue logo chrome, `HelloWorld`, `TheWelcome`, and the placeholder Home/About views. Keep the actual framework baseline: Vue, Vite, TypeScript, Vue Router, Express, multer, and `ts-morph`.
+Vue remains a good fit because the application shell and existing component structure are already Vue, while the hard part is not React versus Vue; it is the graph contract and visual grammar. Vue's composition model is sufficient for the workspace kernel if the mutable interaction state is kept explicit and small.
 
-Do not treat package-lock peer metadata or commented compatibility snippets as legacy application content unless they affect the running app.
+D3 still fits the visual goal because Dimension needs custom topology, ring layouts, scaled links, and data-bound visual states rather than boxed diagram nodes alone. D3 should provide geometry and scale utilities; Dimension should own interaction semantics and graph-to-spell layout.
+
+Scalable Vector Graphics remains the first renderer because it keeps glyphs inspectable, accessible, and easy to style while the grammar changes. Canvas or WebGL rendering should only be introduced when the Scalable Vector Graphics implementation has measured rendering pressure.
+
+Monaco Editor should be used as an inspector companion, not as the visual base. It is useful for read-only source preview, source spans, and later diff views.
+
+Rust and WebAssembly are promising for later source analysis, parsing, or layout workers. Oxc is a Rust JavaScript and TypeScript parser, and SWC exposes browser WebAssembly packages. Those tools become interesting when Dimension needs fast client-side parsing or large-codebase analysis. They should not be the first user interface foundation because WebAssembly complements JavaScript rather than replacing browser application code.
+
+## Frameworks Not Chosen For The First Minimum Viable Product
+
+- **React Flow:** mature and useful as a reference point, but adopting it would require switching the browser shell to React before Dimension has proven its own visual grammar.
+- **Vue Flow:** closer to the current stack and worth revisiting if custom pan, zoom, and selection become a distraction, but it should not own the visual model before the custom workspace kernel is tried.
+- **Eclipse Theia:** too heavy for the first milestone. It is a full integrated development environment framework, while Dimension first needs to prove the visual graph language.
+- **Blockly:** strong for block programming, but Dimension is currently a codebase visualization tool, not a block-language authoring tool.
+- **Excalidraw:** strong open-source paint-like canvas, but it is less directly aligned with a semantic source graph data model. It can inspire spatial interaction, but it should not own the source graph.
+- **tldraw:** strong infinite-canvas user experience, but current production use is source-available and license-key based rather than classic open-source. It should not be the default base unless that licensing tradeoff is accepted.
+
+## Minimum Viable Product Framework Slice
+
+The next implementation slice should build the smallest custom workspace kernel that can replace the static `SpellCanvas` without committing to a third-party graph editor:
+
+1. Split the current `SpellCanvas` into graph data, layout helpers, viewport state, glyph rendering, edge rendering, and inspector state.
+2. Add pan and zoom with browser Pointer Events.
+3. Add node and edge selection with keyboard-focusable Scalable Vector Graphics elements.
+4. Render the existing sample graph through the new primitives.
+5. Keep Dimension glyphs, rings, leylines, parchment styling, and quality markers.
+6. Keep the workspace read-only until the source graph contract is stable.
+7. Compare the result against Vue Flow only if custom interaction work starts dominating the source-backed editor milestone.
+
+## Legacy Content Policy
+
+Remove framework starter and demonstration content, including Vue logo chrome, `HelloWorld`, `TheWelcome`, and placeholder Home and About views. Keep useful project code even if the surrounding framework changes: TypeScript parser code, source graph ideas, visual fixture data, styling direction, and local development helpers.
+
+Do not treat package-lock peer metadata or commented compatibility snippets as legacy application content unless they affect the running application.

--- a/docs/framework-decisions.md
+++ b/docs/framework-decisions.md
@@ -1,5 +1,11 @@
 # Dimension Framework Decisions
 
+## Product Principle
+
+Dimension is no longer centered on helping people hand-write code. It is a project intelligence workspace for humans and AI agents: a way to inspect what was built, understand whether the codebase is organized well, and request high-level structural changes.
+
+The product should favor layered project maps, semantic zoom, source-aware inspection, and organization signals over text-editing chrome. Code views are supporting evidence, not the primary surface.
+
 ## Current Decision
 
 Dimension should keep Vue as the browser application shell for now and build a small Dimension-specific workspace kernel instead of adopting a large editor framework or switching to React only for library availability.
@@ -18,9 +24,9 @@ The workspace kernel is not a general-purpose public library at first. It is pro
 
 ## Why This Stack
 
-Dimension needs a semantic graph workspace with a paint-program feel. Generic node editors are useful references, but Dimension's core interaction is not a stock flowchart. The product needs custom glyphs, rings, leylines, semantic zoom, quality markers, and source-aware inspection.
+Dimension needs a semantic project workspace with a paint-program feel. Generic node editors are useful references, but Dimension's core interaction is not a stock flowchart or a text editor. The product needs custom glyphs, rings, leylines, semantic zoom, quality markers, and source-aware inspection for both humans and AI agents.
 
-Building a small workspace kernel is the better slow solution because the current required primitives are limited: viewport transform, pointer capture, selection state, edge path geometry, node hit boxes, focus management, and inspector updates. Pulling in a full graph editor too early risks fighting its data model and visual defaults.
+Building a small workspace kernel is the better slow solution because the current required primitives are limited: viewport transform, pointer capture, selection state, layered graph layout, node hit boxes, focus management, and inspector updates. Pulling in a full graph editor too early risks fighting its data model and visual defaults.
 
 Vue remains a good fit because the application shell and existing component structure are already Vue, while the hard part is not React versus Vue; it is the graph contract and visual grammar. Vue's composition model is sufficient for the workspace kernel if the mutable interaction state is kept explicit and small.
 

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SERVER_APPLICATION_ORIGIN?: string
+}

--- a/web/index.html
+++ b/web/index.html
@@ -10,7 +10,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0"
     />
-    <title>Vite App</title>
+    <title>Dimension Project Intelligence</title>
   </head>
   <body>
     <div id="app"></div>

--- a/web/src/assets/main.css
+++ b/web/src/assets/main.css
@@ -265,6 +265,12 @@ h1 {
   stroke: rgba(60, 38, 22, 0.72);
 }
 
+
+.leyline--context {
+  stroke: rgba(85, 54, 30, 0.34);
+  stroke-dasharray: 8 14;
+  stroke-width: 2;
+}
 .leyline--response {
   stroke: var(--color-response);
   stroke-width: 5;
@@ -318,6 +324,21 @@ h1 {
   stroke-dasharray: 12 8;
 }
 
+
+.rune--context {
+  opacity: 0.58;
+}
+
+.rune--context circle:first-child {
+  fill: rgba(255, 250, 232, 0.58);
+  stroke: rgba(85, 54, 30, 0.5);
+  stroke-width: 2;
+}
+
+.rune--context text {
+  fill: var(--color-muted);
+  font-size: 0.66rem;
+}
 .rune--policy circle:first-child {
   fill: rgba(245, 225, 169, 0.88);
 }

--- a/web/src/assets/main.css
+++ b/web/src/assets/main.css
@@ -9,7 +9,7 @@
   padding: clamp(1rem, 2vw, 2rem);
   display: grid;
   gap: clamp(1.25rem, 3vw, 3rem);
-  grid-template-columns: minmax(18rem, 0.38fr) minmax(0, 1fr);
+  grid-template-columns: minmax(17rem, 0.3fr) minmax(0, 1fr);
   align-items: stretch;
 }
 
@@ -53,6 +53,72 @@ h1 {
   font-size: clamp(1rem, 1.4vw, 1.25rem);
 }
 
+.source-import {
+  margin: 1.5rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.source-import label {
+  display: grid;
+  gap: 0.45rem;
+  color: var(--color-heading);
+  font-weight: 700;
+}
+
+.source-import input {
+  width: 100%;
+  border: 1px solid var(--color-border);
+  border-radius: 14px;
+  background: rgba(255, 248, 225, 0.68);
+  color: var(--color-text);
+  padding: 0.75rem;
+}
+
+.source-import input:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+.source-import button {
+  justify-self: start;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-parchment);
+  color: var(--color-heading);
+  cursor: pointer;
+  padding: 0.65rem 1rem;
+  font-weight: 700;
+}
+
+.source-import button:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+.source-import input::file-selector-button {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-parchment);
+  color: var(--color-heading);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.source-import__status {
+  min-height: 3.2em;
+  margin: 0;
+  color: var(--color-muted);
+}
+
+.source-import__status--success {
+  color: var(--color-response);
+}
+
+.source-import__status--error {
+  color: var(--color-error);
+}
+
 .framework-grid {
   margin: 2rem 0 0;
   display: grid;
@@ -76,6 +142,43 @@ h1 {
 .framework-grid dd {
   margin: 0.25rem 0 0;
   color: var(--color-heading);
+  font-weight: 700;
+}
+
+.graph-details {
+  margin: 1.25rem 0 0;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  background: rgba(255, 248, 225, 0.54);
+}
+
+.graph-details h2 {
+  margin: 0;
+  color: var(--color-heading);
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 3vw, 2.6rem);
+}
+
+.graph-details p {
+  margin: 0.35rem 0 0;
+  color: var(--color-muted);
+}
+
+.graph-details__links {
+  margin: 0.85rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.graph-details__links button {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-parchment);
+  color: var(--color-heading);
+  cursor: pointer;
+  padding: 0.45rem 0.7rem;
   font-weight: 700;
 }
 
@@ -143,6 +246,11 @@ h1 {
   outline: none;
 }
 
+.rune:hover,
+.rune:focus-visible {
+  cursor: pointer;
+}
+
 .rune circle {
   fill: rgba(255, 250, 232, 0.92);
   stroke: var(--color-ink);
@@ -159,6 +267,13 @@ h1 {
 
 .rune--focus circle:first-child {
   stroke-width: 8;
+}
+
+.rune--selected circle:first-child,
+.rune:hover circle:first-child,
+.rune:focus-visible circle:first-child {
+  stroke: var(--color-accent);
+  stroke-width: 7;
 }
 
 .rune--dashed circle:first-child {

--- a/web/src/assets/main.css
+++ b/web/src/assets/main.css
@@ -105,6 +105,19 @@ h1 {
   font-weight: 700;
 }
 
+.source-import__examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+}
+
+.source-import__examples span {
+  width: 100%;
+  color: var(--color-heading);
+  font-weight: 700;
+}
+
 .source-import__status {
   min-height: 3.2em;
   margin: 0;
@@ -163,6 +176,11 @@ h1 {
   margin: 0.25rem 0 0;
   color: var(--color-heading);
   font-weight: 700;
+}
+
+.framework-grid a {
+  color: inherit;
+  overflow-wrap: anywhere;
 }
 
 .graph-details {

--- a/web/src/assets/main.css
+++ b/web/src/assets/main.css
@@ -111,6 +111,26 @@ h1 {
   color: var(--color-muted);
 }
 
+.source-import__status--loading {
+  color: var(--color-accent);
+  font-weight: 700;
+}
+
+.source-import__status--loading::after {
+  content: "…";
+  animation: loading-pulse 0.8s ease-in-out infinite alternate;
+}
+
+@keyframes loading-pulse {
+  from {
+    opacity: 0.35;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 .source-import__status--success {
   color: var(--color-response);
 }

--- a/web/src/components/SpellCanvas.vue
+++ b/web/src/components/SpellCanvas.vue
@@ -2,17 +2,21 @@
 import { computed } from "vue"
 import { curveCatmullRom, line } from "d3"
 
-import type { EdgeKind, RuneNode, SpellDiagram } from "@/fixtures/usersControllerIndex"
+import type { EdgeKind, RuneNode, SpellDiagram } from "@/types/spell-diagram"
 
 const props = defineProps<{
   diagram: SpellDiagram
 }>()
 
+const emit = defineEmits<{
+  selectNode: [id: string]
+}>()
+
 const nodeById = computed(() => new Map(props.diagram.nodes.map((node) => [node.id, node])))
 
 const pathBuilder = line<[number, number]>()
-  .x(([x]) => x)
-  .y(([, y]) => y)
+  .x((point: [number, number]) => point[0])
+  .y((point: [number, number]) => point[1])
   .curve(curveCatmullRom.alpha(0.5))
 
 const edges = computed(() =>
@@ -39,11 +43,13 @@ function buildEdgePath(source: RuneNode, target: RuneNode): string {
     (source.y + target.y) / 2 - Math.abs(source.x - target.x) * 0.08,
   ]
 
-  return pathBuilder([
-    [source.x, source.y],
-    midpoint,
-    [target.x, target.y],
-  ]) ?? ""
+  return (
+    pathBuilder([
+      [source.x, source.y],
+      midpoint,
+      [target.x, target.y],
+    ]) ?? ""
+  )
 }
 
 function edgeClass(kind: EdgeKind): string {
@@ -51,7 +57,22 @@ function edgeClass(kind: EdgeKind): string {
 }
 
 function nodeClass(node: RuneNode): string {
-  return ["rune", `rune--${node.kind}`, node.ring ? `rune--${node.ring}` : ""].filter(Boolean).join(" ")
+  return [
+    "rune",
+    `rune--${node.kind}`,
+    node.ring ? `rune--${node.ring}` : "",
+    node.isSelected ? "rune--selected" : "",
+  ]
+    .filter(Boolean)
+    .join(" ")
+}
+
+function nodeLabelLines(label: string): string[] {
+  return label
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .split(/[\s_.:/-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
 }
 </script>
 
@@ -99,13 +120,19 @@ function nodeClass(node: RuneNode): string {
           :key="node.id"
           :class="nodeClass(node)"
           :transform="`translate(${node.x} ${node.y})`"
+          role="button"
           tabindex="0"
+          :aria-label="`Select ${node.label}`"
+          :aria-pressed="node.isSelected"
+          @click="emit('selectNode', node.id)"
+          @keydown.enter="emit('selectNode', node.id)"
+          @keydown.space.prevent="emit('selectNode', node.id)"
         >
           <circle :r="node.radius" />
           <circle v-if="node.kind === 'async'" class="async-halo" :r="node.radius + 11" />
           <text text-anchor="middle" dominant-baseline="middle">
             <tspan
-              v-for="(line, index) in node.label.split(' ')"
+              v-for="(line, index) in nodeLabelLines(node.label)"
               :key="`${node.id}-${line}-${index}`"
               x="0"
               :dy="index === 0 ? -7 : 16"

--- a/web/src/components/SpellCanvas.vue
+++ b/web/src/components/SpellCanvas.vue
@@ -101,8 +101,8 @@ function nodeLabelLines(label: string): string[] {
       </defs>
 
       <rect class="parchment" x="24" y="24" width="1032" height="672" rx="34" />
-      <circle class="scope-ring scope-ring--outer" cx="480" cy="330" r="300" />
-      <circle class="scope-ring scope-ring--inner" cx="480" cy="330" r="188" />
+      <circle class="scope-ring scope-ring--outer" cx="540" cy="360" r="300" />
+      <circle class="scope-ring scope-ring--inner" cx="540" cy="360" r="188" />
 
       <g class="leylines" filter="url(#ink-bleed)">
         <path

--- a/web/src/fixtures/publicProjectExamples.ts
+++ b/web/src/fixtures/publicProjectExamples.ts
@@ -1,0 +1,97 @@
+import type { SourceGraph } from "@/types/source-graph"
+
+export interface PublicProjectExample {
+  id: string
+  label: string
+  title: string
+  subtitle: string
+  sourceName: string
+  sourceUrl: string
+  graph: SourceGraph
+}
+
+const travelAuthorizationUrl =
+  "https://github.com/icefoganalytics/travel-authorization/blob/73fe26defe3f8320ee17fc2d6576446764716a5d/api/src/controllers/travel-authorizations-controller.ts"
+const traditionalKnowledgeUrl =
+  "https://github.com/icefoganalytics/traditional-knowledge/blob/03229975b69b29710abfaff249e75a822f28184a/api/src/controllers/information-sharing-agreements-controller.ts"
+const elccUrl =
+  "https://github.com/icefoganalytics/elcc-data-management/blob/dad88f38aaece46bd097e9bbd1a5fc3dfdbe1b34/api/src/controllers/funding-reconciliations-controller.ts"
+
+export const publicProjectExamples: PublicProjectExample[] = [
+  {
+    id: "travel-authorizations",
+    label: "Travel Authorization",
+    title: "TravelAuthorizationsController",
+    subtitle: "Public controller shape for request CRUD, policy checks, serializers, and itinerary loading.",
+    sourceName: "icefoganalytics/travel-authorization/api/src/controllers/travel-authorizations-controller.ts",
+    sourceUrl: travelAuthorizationUrl,
+    graph: controllerGraph("TravelAuthorizationsController", [
+      "index",
+      "show",
+      "create",
+      "update",
+      "destroy",
+      "loadTravelAuthorization",
+      "buildTravelAuthorization",
+      "buildPolicy",
+    ]),
+  },
+  {
+    id: "traditional-knowledge-agreements",
+    label: "Traditional Knowledge",
+    title: "InformationSharingAgreementsController",
+    subtitle: "Public controller shape for agreement lifecycle, confidentiality records, policy, and serialization.",
+    sourceName:
+      "icefoganalytics/traditional-knowledge/api/src/controllers/information-sharing-agreements-controller.ts",
+    sourceUrl: traditionalKnowledgeUrl,
+    graph: controllerGraph("InformationSharingAgreementsController", [
+      "index",
+      "show",
+      "create",
+      "update",
+      "destroy",
+      "loadInformationSharingAgreement",
+      "buildInformationSharingAgreement",
+      "buildPolicy",
+    ]),
+  },
+  {
+    id: "funding-reconciliations",
+    label: "ELCC Data Management",
+    title: "FundingReconciliationsController",
+    subtitle: "Public controller shape for reconciliation CRUD, adjustment loading, policy, and serializers.",
+    sourceName: "icefoganalytics/elcc-data-management/api/src/controllers/funding-reconciliations-controller.ts",
+    sourceUrl: elccUrl,
+    graph: controllerGraph("FundingReconciliationsController", [
+      "index",
+      "show",
+      "create",
+      "update",
+      "destroy",
+      "loadFundingReconciliation",
+      "buildPolicy",
+    ]),
+  },
+]
+
+function controllerGraph(className: string, methods: string[]): SourceGraph {
+  const classId = `class:${className}`
+  const nodes: SourceGraph["nodes"] = [{ id: classId, label: className, type: "class" }]
+  const links: SourceGraph["links"] = []
+
+  methods.forEach((method) => {
+    const methodId = `${classId}:method:${method}`
+    nodes.push({ id: methodId, label: method, type: methodType(method) })
+    links.push({ source: classId, target: methodId })
+  })
+
+  return { nodes, links }
+}
+
+function methodType(method: string): string {
+  if (method === "buildPolicy") return "policy"
+  if (method.startsWith("load")) return "async"
+  if (method.startsWith("build")) return "helper"
+
+  return "method"
+}

--- a/web/src/fixtures/usersControllerIndex.ts
+++ b/web/src/fixtures/usersControllerIndex.ts
@@ -1,30 +1,4 @@
-export type RuneKind = "method" | "local" | "policy" | "async" | "response" | "error"
-
-export type EdgeKind = "data" | "error" | "response"
-
-export interface RuneNode {
-  id: string
-  label: string
-  kind: RuneKind
-  x: number
-  y: number
-  radius: number
-  ring?: "solid" | "dashed" | "focus"
-}
-
-export interface LeylineEdge {
-  id: string
-  source: string
-  target: string
-  kind: EdgeKind
-}
-
-export interface SpellDiagram {
-  title: string
-  subtitle: string
-  nodes: RuneNode[]
-  edges: LeylineEdge[]
-}
+import type { SpellDiagram } from "@/types/spell-diagram"
 
 export const usersControllerIndexDiagram: SpellDiagram = {
   title: "UsersController#index",

--- a/web/src/services/graph-import-service.ts
+++ b/web/src/services/graph-import-service.ts
@@ -1,0 +1,40 @@
+import type { SourceGraph } from "@/types/source-graph"
+
+const serverApplicationOrigin = import.meta.env.VITE_SERVER_APPLICATION_ORIGIN?.replace(/\/$/, "") ?? ""
+
+interface GraphImportResponse {
+  graph?: SourceGraph
+  message?: string
+}
+
+export async function createGraphFromSourceFile(file: File): Promise<SourceGraph> {
+  const formData = new FormData()
+  formData.append("file", file)
+
+  const response = await fetch(`${serverApplicationOrigin}/graphs`, {
+    method: "POST",
+    body: formData,
+  })
+
+  const responseBody = await readGraphImportResponse(response)
+
+  if (!response.ok) {
+    throw new Error(responseBody.message ?? `The source importer rejected ${file.name}.`)
+  }
+
+  if (!responseBody.graph) {
+    throw new Error("The source importer did not return a graph.")
+  }
+
+  return responseBody.graph
+}
+
+async function readGraphImportResponse(response: Response): Promise<GraphImportResponse> {
+  try {
+    return (await response.json()) as GraphImportResponse
+  } catch {
+    return {
+      message: response.ok ? undefined : "The source importer returned an unreadable response.",
+    }
+  }
+}

--- a/web/src/services/project-folder-service.ts
+++ b/web/src/services/project-folder-service.ts
@@ -1,0 +1,62 @@
+import type { SourceGraph, SourceLink, SourceNode } from "@/types/source-graph"
+
+const GENERATED_DIRECTORIES = new Set([".git", ".vite", "coverage", "dist", "node_modules"])
+
+export function createProjectGraphFromFiles(fileList: FileList): SourceGraph {
+  const files = Array.from(fileList)
+  const nodes = new Map<string, SourceNode>()
+  const links: SourceLink[] = []
+  const linkIds = new Set<string>()
+  const projectName = projectNameForFiles(files)
+  const rootId = `folder:${projectName}`
+
+  pushNode(nodes, {
+    id: rootId,
+    label: projectName,
+    type: "folder",
+  })
+
+  files.forEach((file) => {
+    const path = file.webkitRelativePath || file.name
+    const parts = path.split("/").filter(Boolean)
+    const childName = file.webkitRelativePath ? parts[1] : parts[0]
+
+    if (!childName || GENERATED_DIRECTORIES.has(childName)) return
+
+    const isFolder = file.webkitRelativePath ? parts.length > 2 : false
+    const childType = isFolder ? "folder" : "file"
+    const childId = `${childType}:${projectName}/${childName}`
+
+    pushNode(nodes, {
+      id: childId,
+      label: childName,
+      type: childType,
+    })
+    pushLink(links, linkIds, rootId, childId)
+  })
+
+  return {
+    nodes: Array.from(nodes.values()),
+    links,
+  }
+}
+
+function projectNameForFiles(files: File[]): string {
+  const path = files[0]?.webkitRelativePath
+  const root = path?.split("/").filter(Boolean)[0]
+
+  return root || "Selected project"
+}
+
+function pushNode(nodes: Map<string, SourceNode>, node: SourceNode): void {
+  if (!nodes.has(node.id)) nodes.set(node.id, node)
+}
+
+function pushLink(links: SourceLink[], linkIds: Set<string>, source: string, target: string): void {
+  const id = `${source}->${target}`
+
+  if (linkIds.has(id)) return
+
+  linkIds.add(id)
+  links.push({ source, target })
+}

--- a/web/src/services/spell-diagram-adapter.ts
+++ b/web/src/services/spell-diagram-adapter.ts
@@ -1,0 +1,197 @@
+import type { SourceGraph, SourceLink, SourceNode } from "@/types/source-graph"
+import type { EdgeKind, RuneKind, RuneNode, SpellDiagram } from "@/types/spell-diagram"
+
+const CANVAS_WIDTH = 1080
+const CANVAS_HEIGHT = 720
+const CENTER_X = CANVAS_WIDTH / 2
+const CENTER_Y = CANVAS_HEIGHT / 2
+const LAYOUT_RADIUS_X = 300
+const LAYOUT_RADIUS_Y = 205
+const DENSE_GRAPH_LIMIT = 28
+
+export interface SpellDiagramInput {
+  graph: SourceGraph
+  title: string
+  subtitle: string
+  selectedNodeId?: string
+}
+
+export function createSpellDiagramFromSourceGraph(input: SpellDiagramInput): SpellDiagram {
+  const sourceNodes = input.graph.nodes.length > 0 ? input.graph.nodes : [emptySourceNode()]
+  const focusNode = focusNodeFor(sourceNodes, input.selectedNodeId)
+  const visibleNodes = visibleSourceNodes(sourceNodes, input.graph.links, focusNode)
+  const visibleNodeIds = new Set(visibleNodes.map((node) => node.id))
+  const hiddenCount = sourceNodes.length - visibleNodes.length
+  const subtitle =
+    hiddenCount > 0
+      ? `${input.subtitle} Showing ${visibleNodes.length} of ${sourceNodes.length}; click a linked rune to refocus.`
+      : input.subtitle
+
+  return {
+    title: input.title,
+    subtitle,
+    nodes: visibleNodes.map((node, index) =>
+      createRuneNode(node, index, visibleNodes.length, node.id === focusNode.id, node.id === input.selectedNodeId),
+    ),
+    edges: input.graph.links
+      .filter((link) => visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target))
+      .map((link, index) => ({
+        id: `${link.source}-${link.target}-${index}`,
+        source: link.source,
+        target: link.target,
+        kind: edgeKindForTarget(visibleNodes.find((node) => node.id === link.target)),
+      })),
+  }
+}
+
+function focusNodeFor(nodes: SourceNode[], selectedNodeId: string | undefined): SourceNode {
+  return nodes.find((node) => node.id === selectedNodeId) ?? nodes.find((node) => node.type === "method") ?? nodes[0]
+}
+
+function visibleSourceNodes(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): SourceNode[] {
+  if (isLayerNode(focusNode)) return firstLayerNodes(nodes, links, focusNode)
+
+  if (nodes.length <= DENSE_GRAPH_LIMIT) return nodes
+
+  const visibleIds = new Set<string>([focusNode.id])
+  const directIds = linkedNodeIds(links, focusNode.id)
+
+  directIds.forEach((id) => visibleIds.add(id))
+  siblingMethodIds(nodes, links, focusNode).forEach((id) => visibleIds.add(id))
+
+  return [focusNode, ...nodes.filter((node) => node.id !== focusNode.id && visibleIds.has(node.id))].slice(
+    0,
+    DENSE_GRAPH_LIMIT,
+  )
+}
+
+function firstLayerNodes(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): SourceNode[] {
+  const visibleIds = linkedNodeIds(links, focusNode.id)
+
+  return [focusNode, ...nodes.filter((node) => visibleIds.has(node.id))].slice(0, DENSE_GRAPH_LIMIT)
+}
+
+function isLayerNode(node: SourceNode): boolean {
+  return node.type === "class" || node.type === "folder"
+}
+
+function linkedNodeIds(links: SourceLink[], nodeId: string): Set<string> {
+  const ids = new Set<string>()
+
+  links.forEach((link) => {
+    if (link.source === nodeId) ids.add(link.target)
+    if (link.target === nodeId) ids.add(link.source)
+  })
+
+  return ids
+}
+
+function siblingMethodIds(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): string[] {
+  if (focusNode.type !== "method") return []
+
+  const parentIds = links.filter((link) => link.target === focusNode.id).map((link) => link.source)
+
+  return links
+    .filter((link) => parentIds.includes(link.source) && link.target !== focusNode.id)
+    .map((link) => nodes.find((node) => node.id === link.target))
+    .filter((node): node is SourceNode => node?.type === "method")
+    .map((node) => node.id)
+}
+
+function createRuneNode(
+  node: SourceNode,
+  index: number,
+  count: number,
+  isFocus: boolean,
+  isSelected: boolean,
+): RuneNode {
+  if (isFocus) {
+    return {
+      id: node.id,
+      label: node.label,
+      kind: runeKindForSourceType(node.type),
+      x: CENTER_X,
+      y: CENTER_Y,
+      radius: radiusForSourceType(node.type, true),
+      ring: "focus",
+      isSelected,
+    }
+  }
+
+  const angle = (Math.PI * 2 * index) / Math.max(count - 1, 1) - Math.PI / 2
+
+  return {
+    id: node.id,
+    label: node.label,
+    kind: runeKindForSourceType(node.type),
+    x: Math.round(CENTER_X + Math.cos(angle) * LAYOUT_RADIUS_X),
+    y: Math.round(CENTER_Y + Math.sin(angle) * LAYOUT_RADIUS_Y),
+    radius: radiusForSourceType(node.type, false),
+    ring: ringForSourceType(node.type),
+    isSelected,
+  }
+}
+
+function runeKindForSourceType(type: string): RuneKind {
+  switch (type) {
+    case "async":
+      return "async"
+    case "error":
+      return "error"
+    case "response":
+      return "response"
+    case "policy":
+      return "policy"
+    case "class":
+    case "folder":
+    case "method":
+      return "method"
+    default:
+      return "local"
+  }
+}
+
+function edgeKindForTarget(target: SourceNode | undefined): EdgeKind {
+  switch (target?.type) {
+    case "error":
+      return "error"
+    case "response":
+      return "response"
+    default:
+      return "data"
+  }
+}
+
+function ringForSourceType(type: string): RuneNode["ring"] {
+  switch (type) {
+    case "error":
+    case "policy":
+      return "dashed"
+    default:
+      return "solid"
+  }
+}
+
+function radiusForSourceType(type: string, isFocus: boolean): number {
+  if (isFocus) return 84
+
+  switch (type) {
+    case "class":
+    case "folder":
+      return 62
+    case "method":
+      return 50
+    case "response":
+      return 46
+    default:
+      return 40
+  }
+}
+
+function emptySourceNode(): SourceNode {
+  return {
+    id: "empty-source",
+    label: "No code found",
+    type: "response",
+  }
+}

--- a/web/src/services/spell-diagram-adapter.ts
+++ b/web/src/services/spell-diagram-adapter.ts
@@ -94,7 +94,7 @@ function siblingMethodIds(nodes: SourceNode[], links: SourceLink[], focusNode: S
   return links
     .filter((link) => parentIds.includes(link.source) && link.target !== focusNode.id)
     .map((link) => nodes.find((node) => node.id === link.target))
-    .filter((node): node is SourceNode => node?.type === "method")
+    .filter((node): node is SourceNode => Boolean(node && node.id.includes(":method:")))
     .map((node) => node.id)
 }
 

--- a/web/src/services/spell-diagram-adapter.ts
+++ b/web/src/services/spell-diagram-adapter.ts
@@ -8,6 +8,10 @@ const CENTER_Y = CANVAS_HEIGHT / 2
 const LAYOUT_RADIUS_X = 300
 const LAYOUT_RADIUS_Y = 205
 const DENSE_GRAPH_LIMIT = 28
+const CONTEXT_X = 175
+const CONTEXT_START_Y = 150
+const CONTEXT_GAP_Y = 72
+const DETAIL_LIMIT = 14
 
 export interface SpellDiagramInput {
   graph: SourceGraph
@@ -31,16 +35,35 @@ export function createSpellDiagramFromSourceGraph(input: SpellDiagramInput): Spe
     title: input.title,
     subtitle,
     nodes: visibleNodes.map((node, index) =>
-      createRuneNode(node, index, visibleNodes.length, node.id === focusNode.id, node.id === input.selectedNodeId),
+      createRuneNode(
+        node,
+        index,
+        visibleNodes.length,
+        node.id === focusNode.id,
+        node.id === input.selectedNodeId,
+        contextIndex(visibleNodes, index),
+        contextCount(visibleNodes),
+        detailIndex(visibleNodes, index),
+        detailCount(visibleNodes),
+      ),
     ),
     edges: input.graph.links
       .filter((link) => visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target))
-      .map((link, index) => ({
-        id: `${link.source}-${link.target}-${index}`,
-        source: link.source,
-        target: link.target,
-        kind: edgeKindForTarget(visibleNodes.find((node) => node.id === link.target)),
-      })),
+      .flatMap((link, index) => {
+        const source = visibleNodes.find((node) => node.id === link.source)
+        const target = visibleNodes.find((node) => node.id === link.target)
+
+        if (source?.type === "context" && target?.type === "context") return []
+
+        return [
+          {
+            id: `${link.source}-${link.target}-${index}`,
+            source: link.source,
+            target: link.target,
+            kind: edgeKindFor(source, target),
+          },
+        ]
+      }),
   }
 }
 
@@ -51,18 +74,19 @@ function focusNodeFor(nodes: SourceNode[], selectedNodeId: string | undefined): 
 function visibleSourceNodes(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): SourceNode[] {
   if (isLayerNode(focusNode)) return firstLayerNodes(nodes, links, focusNode)
 
-  if (nodes.length <= DENSE_GRAPH_LIMIT) return nodes
-
-  const visibleIds = new Set<string>([focusNode.id])
+  const parentNodes = parentContextNodes(nodes, links, focusNode)
   const directIds = linkedNodeIds(links, focusNode.id)
+  parentNodes.forEach((node) => directIds.delete(node.id))
 
-  directIds.forEach((id) => visibleIds.add(id))
-  siblingMethodIds(nodes, links, focusNode).forEach((id) => visibleIds.add(id))
+  const siblingNodes = siblingMethodIds(nodes, links, focusNode)
+    .map((id) => nodes.find((node) => node.id === id))
+    .filter((node): node is SourceNode => Boolean(node))
+    .slice(0, 6)
+    .map(asContextNode)
 
-  return [focusNode, ...nodes.filter((node) => node.id !== focusNode.id && visibleIds.has(node.id))].slice(
-    0,
-    DENSE_GRAPH_LIMIT,
-  )
+  const detailNodes = nodes.filter((node) => directIds.has(node.id)).slice(0, DETAIL_LIMIT)
+
+  return [focusNode, ...parentNodes.map(asContextNode), ...siblingNodes, ...detailNodes]
 }
 
 function firstLayerNodes(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): SourceNode[] {
@@ -87,7 +111,7 @@ function linkedNodeIds(links: SourceLink[], nodeId: string): Set<string> {
 }
 
 function siblingMethodIds(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): string[] {
-  if (focusNode.type !== "method") return []
+  if (!focusNode.id.includes(":method:")) return []
 
   const parentIds = links.filter((link) => link.target === focusNode.id).map((link) => link.source)
 
@@ -98,12 +122,47 @@ function siblingMethodIds(nodes: SourceNode[], links: SourceLink[], focusNode: S
     .map((node) => node.id)
 }
 
+function parentContextNodes(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): SourceNode[] {
+  return links
+    .filter((link) => link.target === focusNode.id)
+    .map((link) => nodes.find((node) => node.id === link.source))
+    .filter((node): node is SourceNode => Boolean(node))
+    .slice(0, 1)
+}
+
+function asContextNode(node: SourceNode): SourceNode {
+  return {
+    ...node,
+    type: "context",
+  }
+}
+
+function contextCount(nodes: SourceNode[]): number {
+  return nodes.filter((node) => node.type === "context").length
+}
+
+function contextIndex(nodes: SourceNode[], index: number): number {
+  return nodes.slice(0, index).filter((node) => node.type === "context").length
+}
+
+function detailCount(nodes: SourceNode[]): number {
+  return nodes.filter((node) => node.type !== "context").length - 1
+}
+
+function detailIndex(nodes: SourceNode[], index: number): number {
+  return nodes.slice(0, index).filter((node) => node.type !== "context").length - 1
+}
+
 function createRuneNode(
   node: SourceNode,
   index: number,
   count: number,
   isFocus: boolean,
   isSelected: boolean,
+  nodeContextIndex: number,
+  nodeContextCount: number,
+  nodeDetailIndex: number,
+  nodeDetailCount: number,
 ): RuneNode {
   if (isFocus) {
     return {
@@ -118,8 +177,23 @@ function createRuneNode(
     }
   }
 
-  const angle = (Math.PI * 2 * index) / Math.max(count - 1, 1) - Math.PI / 2
+  if (node.type === "context") {
+    return {
+      id: node.id,
+      label: node.label,
+      kind: "context",
+      x: CONTEXT_X,
+      y: CONTEXT_START_Y + nodeContextIndex * Math.min(CONTEXT_GAP_Y, 500 / Math.max(nodeContextCount, 1)),
+      radius: radiusForSourceType(node.type, false),
+      ring: "dashed",
+      isSelected,
+    }
+  }
 
+  const detailAngle =
+    nodeDetailCount <= 1 ? 0 : (Math.PI * 1.45 * nodeDetailIndex) / Math.max(nodeDetailCount - 1, 1) - Math.PI * 0.72
+
+  const angle = nodeContextCount > 0 ? detailAngle : (Math.PI * 2 * index) / Math.max(count - 1, 1) - Math.PI / 2
   return {
     id: node.id,
     label: node.label,
@@ -136,6 +210,8 @@ function runeKindForSourceType(type: string): RuneKind {
   switch (type) {
     case "async":
       return "async"
+    case "context":
+      return "context"
     case "error":
       return "error"
     case "response":
@@ -151,7 +227,9 @@ function runeKindForSourceType(type: string): RuneKind {
   }
 }
 
-function edgeKindForTarget(target: SourceNode | undefined): EdgeKind {
+function edgeKindFor(source: SourceNode | undefined, target: SourceNode | undefined): EdgeKind {
+  if (source?.type === "context" || target?.type === "context") return "context"
+
   switch (target?.type) {
     case "error":
       return "error"
@@ -161,6 +239,7 @@ function edgeKindForTarget(target: SourceNode | undefined): EdgeKind {
       return "data"
   }
 }
+
 
 function ringForSourceType(type: string): RuneNode["ring"] {
   switch (type) {
@@ -176,6 +255,8 @@ function radiusForSourceType(type: string, isFocus: boolean): number {
   if (isFocus) return 84
 
   switch (type) {
+    case "context":
+      return 34
     case "class":
     case "folder":
       return 62

--- a/web/src/types/source-graph.ts
+++ b/web/src/types/source-graph.ts
@@ -1,0 +1,15 @@
+export interface SourceNode {
+  id: string
+  label: string
+  type: string
+}
+
+export interface SourceLink {
+  source: string
+  target: string
+}
+
+export interface SourceGraph {
+  nodes: SourceNode[]
+  links: SourceLink[]
+}

--- a/web/src/types/spell-diagram.ts
+++ b/web/src/types/spell-diagram.ts
@@ -1,0 +1,28 @@
+export type RuneKind = "method" | "local" | "policy" | "async" | "response" | "error"
+
+export type EdgeKind = "data" | "error" | "response"
+
+export interface RuneNode {
+  id: string
+  label: string
+  kind: RuneKind
+  x: number
+  y: number
+  radius: number
+  ring?: "solid" | "dashed" | "focus"
+  isSelected?: boolean
+}
+
+export interface LeylineEdge {
+  id: string
+  source: string
+  target: string
+  kind: EdgeKind
+}
+
+export interface SpellDiagram {
+  title: string
+  subtitle: string
+  nodes: RuneNode[]
+  edges: LeylineEdge[]
+}

--- a/web/src/types/spell-diagram.ts
+++ b/web/src/types/spell-diagram.ts
@@ -1,6 +1,6 @@
-export type RuneKind = "method" | "local" | "policy" | "async" | "response" | "error"
+export type RuneKind = "method" | "local" | "policy" | "async" | "response" | "error" | "context"
 
-export type EdgeKind = "data" | "error" | "response"
+export type EdgeKind = "data" | "error" | "response" | "context"
 
 export interface RuneNode {
   id: string

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -1,34 +1,257 @@
 <script setup lang="ts">
+import { computed, ref } from "vue"
+
 import SpellCanvas from "@/components/SpellCanvas.vue"
 import { usersControllerIndexDiagram } from "@/fixtures/usersControllerIndex"
+import { createGraphFromSourceFile } from "@/services/graph-import-service"
+import { createProjectGraphFromFiles } from "@/services/project-folder-service"
+import { createSpellDiagramFromSourceGraph } from "@/services/spell-diagram-adapter"
+import type { SourceGraph } from "@/types/source-graph"
+import type { RuneNode, SpellDiagram } from "@/types/spell-diagram"
+
+const builtInSourceName = "Built-in controller fixture"
+const defaultImportMessage = "Upload a source file for layered code review, or select a folder for a filename-only map."
+const builtInSubtitle = "Controller fixture for reviewing project organization across method, policy, query, and response layers."
+const workspaceStorageKey = "dimension:last-workspace"
+const persistedWorkspace = readPersistedWorkspace()
+
+interface PersistedWorkspace {
+  graph: SourceGraph
+  title: string
+  subtitle: string
+  sourceName: string
+  selectedNodeId?: string
+  message: string
+}
+
+const sourceGraph = ref<SourceGraph | undefined>(persistedWorkspace?.graph)
+const diagramTitle = ref(persistedWorkspace?.title ?? builtInSourceName)
+const diagramSubtitle = ref(persistedWorkspace?.subtitle ?? builtInSubtitle)
+const selectedSourceName = ref(persistedWorkspace?.sourceName ?? builtInSourceName)
+const selectedNodeId = ref<string | undefined>(persistedWorkspace?.selectedNodeId)
+const importStatus = ref<"idle" | "loading" | "success" | "error">(persistedWorkspace ? "success" : "idle")
+const importMessage = ref(persistedWorkspace?.message ?? defaultImportMessage)
+const isImporting = computed(() => importStatus.value === "loading")
+const currentDiagram = computed<SpellDiagram>(() => {
+  if (!sourceGraph.value) return usersControllerIndexDiagram
+
+  return createSpellDiagramFromSourceGraph({
+    graph: sourceGraph.value,
+    title: diagramTitle.value,
+    subtitle: diagramSubtitle.value,
+    selectedNodeId: selectedNodeId.value,
+  })
+})
+const selectedNode = computed(() => currentDiagram.value.nodes.find((node) => node.id === selectedNodeId.value))
+const selectedConnections = computed(() => connectedNodes(currentDiagram.value, selectedNode.value))
+
+function loadBuiltInSample(): void {
+  sourceGraph.value = undefined
+  diagramTitle.value = builtInSourceName
+  diagramSubtitle.value = builtInSubtitle
+  selectedSourceName.value = builtInSourceName
+  selectedNodeId.value = undefined
+  importStatus.value = "idle"
+  importMessage.value = defaultImportMessage
+  clearPersistedWorkspace()
+}
+
+async function importSourceFile(event: Event): Promise<void> {
+  const input = event.target as HTMLInputElement
+  const sourceFile = input.files?.[0]
+
+  if (!sourceFile) return
+
+  importStatus.value = "loading"
+  importMessage.value = `Parsing ${sourceFile.name} through the server importer…`
+
+  try {
+    const graph = await createGraphFromSourceFile(sourceFile)
+    const selectedId = firstLayerNodeId(graph) ?? graph.nodes[0]?.id
+    const message = `Mapped ${graph.nodes.length} code parts and ${graph.links.length} links from ${sourceFile.name}.`
+
+    setWorkspace({
+      graph,
+      title: sourceFile.name,
+      subtitle: "High-level code map imported from the server parser.",
+      sourceName: sourceFile.name,
+      selectedNodeId: selectedId,
+      message,
+    })
+  } catch (error) {
+    importStatus.value = "error"
+    importMessage.value = error instanceof Error ? error.message : "The source importer could not render that file."
+  } finally {
+    input.value = ""
+  }
+}
+
+function importProjectFolder(event: Event): void {
+  const input = event.target as HTMLInputElement
+  const files = input.files
+
+  if (!files?.length) return
+
+  const graph = createProjectGraphFromFiles(files)
+  const folderName = graph.nodes[0]?.label ?? "Selected project"
+  const selectedId = graph.nodes[0]?.id
+  const message = `Mapped ${directChildCount(graph, selectedId)} first-layer items from ${folderName}; file contents stayed local.`
+
+  setWorkspace({
+    graph,
+    title: folderName,
+    subtitle: "Filename-only project map. This MVP shows the selected folder's direct children only.",
+    sourceName: folderName,
+    selectedNodeId: selectedId,
+    message,
+  })
+  input.value = ""
+}
+
+function selectNode(id: string): void {
+  selectedNodeId.value = id
+  persistCurrentWorkspace()
+}
+
+function setWorkspace(workspace: PersistedWorkspace): void {
+  sourceGraph.value = workspace.graph
+  diagramTitle.value = workspace.title
+  diagramSubtitle.value = workspace.subtitle
+  selectedSourceName.value = workspace.sourceName
+  selectedNodeId.value = workspace.selectedNodeId
+  importStatus.value = "success"
+  importMessage.value = workspace.message
+  persistWorkspace(workspace)
+}
+
+function persistCurrentWorkspace(): void {
+  if (!sourceGraph.value) return
+
+  persistWorkspace({
+    graph: sourceGraph.value,
+    title: diagramTitle.value,
+    subtitle: diagramSubtitle.value,
+    sourceName: selectedSourceName.value,
+    selectedNodeId: selectedNodeId.value,
+    message: importMessage.value,
+  })
+}
+
+function firstLayerNodeId(graph: SourceGraph): string | undefined {
+  return graph.nodes.find((node) => node.type === "class" || node.type === "folder")?.id ?? graph.nodes[0]?.id
+}
+
+function directChildCount(graph: SourceGraph, nodeId: string | undefined): number {
+  if (!nodeId) return 0
+
+  return graph.links.filter((link) => link.source === nodeId).length
+}
+
+function connectedNodes(diagram: SpellDiagram, node: RuneNode | undefined): RuneNode[] {
+  if (!node) return []
+
+  const connectionIds = new Set<string>()
+
+  diagram.edges.forEach((edge) => {
+    if (edge.source === node.id) connectionIds.add(edge.target)
+    if (edge.target === node.id) connectionIds.add(edge.source)
+  })
+
+  return diagram.nodes.filter((candidate) => connectionIds.has(candidate.id))
+}
+
+function readPersistedWorkspace(): PersistedWorkspace | undefined {
+  try {
+    const value = localStorage.getItem(workspaceStorageKey)
+
+    return value ? (JSON.parse(value) as PersistedWorkspace) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function persistWorkspace(workspace: PersistedWorkspace): void {
+  try {
+    localStorage.setItem(workspaceStorageKey, JSON.stringify(workspace))
+  } catch {
+    // Best effort only. The in-memory workspace is still loaded.
+  }
+}
+
+function clearPersistedWorkspace(): void {
+  try {
+    localStorage.removeItem(workspaceStorageKey)
+  } catch {
+    // Best effort only. The built-in sample is still loaded.
+  }
+}
 </script>
 
 <template>
   <main class="workspace">
     <section class="hero-panel" aria-labelledby="dimension-title">
-      <p class="eyebrow">Pen-first visual programming</p>
-      <h1 id="dimension-title">Draw spells, not code.</h1>
+      <p class="eyebrow">Project intelligence for humans and agents</p>
+      <h1 id="dimension-title">See what AI built.</h1>
       <p class="hero-copy">
-        Dimension turns controller logic into glyphs, scoped rings, and data-flow leylines. This first
-        screen keeps the stack boring: Vue for the shell, D3 for SVG geometry, and TypeScript data for
-        the visual grammar.
+        Dimension maps project code into browsable layers so humans and AI agents can inspect structure,
+        spot organization problems, and ask for focused changes without reading every file by hand.
       </p>
-      <dl class="framework-grid" aria-label="Selected frameworks">
+      <form class="source-import" aria-label="Import source file or project folder">
+        <label>
+          <span>Source file</span>
+          <input
+            type="file"
+            accept=".ts,.tsx,.rb,text/typescript,text/x-ruby"
+            :disabled="isImporting"
+            @change="importSourceFile"
+          />
+        </label>
+        <label>
+          <span>Project folder</span>
+          <input type="file" webkitdirectory multiple :disabled="isImporting" @change="importProjectFolder" />
+        </label>
+        <button type="button" :disabled="isImporting" @click="loadBuiltInSample">Load built-in sample</button>
+        <p class="source-import__status" :class="`source-import__status--${importStatus}`" aria-live="polite">
+          {{ importMessage }}
+        </p>
+      </form>
+      <dl class="framework-grid" aria-label="Current source graph">
         <div>
-          <dt>Interface</dt>
-          <dd>Vue 3 + Vite</dd>
+          <dt>Source</dt>
+          <dd>{{ selectedSourceName }}</dd>
         </div>
         <div>
-          <dt>Visualization</dt>
-          <dd>D3-driven SVG</dd>
+          <dt>Visual shell</dt>
+          <dd>Vue 3 + Scalable Vector Graphics</dd>
         </div>
         <div>
           <dt>Source import</dt>
           <dd>Express + ts-morph</dd>
         </div>
       </dl>
+      <section class="graph-details" aria-label="Selected rune details">
+        <p class="eyebrow">Navigation</p>
+        <h2>{{ selectedNode?.label ?? "Click a rune" }}</h2>
+        <p>
+          {{
+            selectedNode
+              ? `${selectedConnections.length} linked rune${selectedConnections.length === 1 ? "" : "s"}`
+              : "Select any rune to see linked neighbors and refocus dense graphs."
+          }}
+        </p>
+        <div v-if="selectedConnections.length" class="graph-details__links">
+          <button
+            v-for="connection in selectedConnections"
+            :key="connection.id"
+            type="button"
+            @click="selectNode(connection.id)"
+          >
+            {{ connection.label }}
+          </button>
+        </div>
+      </section>
     </section>
 
-    <SpellCanvas :diagram="usersControllerIndexDiagram" />
+    <SpellCanvas :diagram="currentDiagram" @select-node="selectNode" />
   </main>
 </template>

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, ref } from "vue"
 
 import SpellCanvas from "@/components/SpellCanvas.vue"
 import { usersControllerIndexDiagram } from "@/fixtures/usersControllerIndex"
+import { publicProjectExamples, type PublicProjectExample } from "@/fixtures/publicProjectExamples"
 import { createGraphFromSourceFile } from "@/services/graph-import-service"
 import { createProjectGraphFromFiles } from "@/services/project-folder-service"
 import { createSpellDiagramFromSourceGraph } from "@/services/spell-diagram-adapter"
@@ -13,8 +14,10 @@ const builtInSourceName = "Built-in controller fixture"
 const defaultImportMessage = "Upload a source file for layered code review, or select a folder for a filename-only map."
 const builtInSubtitle = "Controller fixture for reviewing project organization across method, policy, query, and response layers."
 const workspaceStorageKey = "dimension:last-workspace"
-const persistedWorkspace = readPersistedWorkspace()
-
+const defaultPageTitle = "Dimension Project Intelligence"
+const urlExample = readExampleFromUrl()
+const storedWorkspace = readPersistedWorkspace()
+const persistedWorkspace = urlExample ? workspaceFromExample(urlExample, storedWorkspace) : storedWorkspace
 interface PersistedWorkspace {
   graph: SourceGraph
   title: string
@@ -22,12 +25,16 @@ interface PersistedWorkspace {
   sourceName: string
   selectedNodeId?: string
   message: string
+  exampleId?: string
+  sourceUrl?: string
 }
 
 const sourceGraph = ref<SourceGraph | undefined>(persistedWorkspace?.graph)
 const diagramTitle = ref(persistedWorkspace?.title ?? builtInSourceName)
 const diagramSubtitle = ref(persistedWorkspace?.subtitle ?? builtInSubtitle)
 const selectedSourceName = ref(persistedWorkspace?.sourceName ?? builtInSourceName)
+const selectedSourceUrl = ref<string | undefined>(persistedWorkspace?.sourceUrl)
+const selectedExampleId = ref<string | undefined>(persistedWorkspace?.exampleId)
 const selectedNodeId = ref<string | undefined>(persistedWorkspace?.selectedNodeId)
 const importStatus = ref<"idle" | "loading" | "success" | "error">(persistedWorkspace ? "success" : "idle")
 const importMessage = ref(persistedWorkspace?.message ?? defaultImportMessage)
@@ -44,16 +51,25 @@ const currentDiagram = computed<SpellDiagram>(() => {
 })
 const selectedNode = computed(() => currentDiagram.value.nodes.find((node) => node.id === selectedNodeId.value))
 const selectedConnections = computed(() => connectedNodes(currentDiagram.value, selectedNode.value))
+syncDocumentTitle(diagramTitle.value)
 
 function loadBuiltInSample(): void {
   sourceGraph.value = undefined
   diagramTitle.value = builtInSourceName
   diagramSubtitle.value = builtInSubtitle
   selectedSourceName.value = builtInSourceName
+  selectedSourceUrl.value = undefined
   selectedNodeId.value = undefined
   importStatus.value = "idle"
+  selectedExampleId.value = undefined
   importMessage.value = defaultImportMessage
   clearPersistedWorkspace()
+  replaceUrlState()
+  syncDocumentTitle(builtInSourceName)
+}
+
+function loadPublicProjectExample(example: PublicProjectExample): void {
+  setWorkspace(workspaceFromExample(example))
 }
 
 async function importSourceFile(event: Event): Promise<void> {
@@ -75,6 +91,7 @@ async function importSourceFile(event: Event): Promise<void> {
       title: sourceFile.name,
       subtitle: "High-level code map imported from the server parser.",
       sourceName: sourceFile.name,
+      sourceUrl: undefined,
       selectedNodeId: selectedId,
       message,
     })
@@ -107,6 +124,7 @@ async function importProjectFolder(event: Event): Promise<void> {
       title: folderName,
       subtitle: "Filename-only project map. This MVP shows the selected folder's direct children only.",
       sourceName: folderName,
+      sourceUrl: undefined,
       selectedNodeId: selectedId,
       message,
     })
@@ -128,10 +146,15 @@ function setWorkspace(workspace: PersistedWorkspace): void {
   diagramTitle.value = workspace.title
   diagramSubtitle.value = workspace.subtitle
   selectedSourceName.value = workspace.sourceName
+  selectedSourceUrl.value = workspace.sourceUrl
   selectedNodeId.value = workspace.selectedNodeId
   importStatus.value = "success"
-  importMessage.value = workspace.message
-  persistWorkspace(workspace)
+  selectedExampleId.value = workspace.exampleId
+  importMessage.value = persistWorkspace(workspace)
+    ? workspace.message
+    : `${workspace.message} This graph is loaded, but browser storage refused to save it for refresh.`
+  replaceUrlState(workspace)
+  syncDocumentTitle(workspace.title)
 }
 
 function persistCurrentWorkspace(): void {
@@ -142,8 +165,10 @@ function persistCurrentWorkspace(): void {
     title: diagramTitle.value,
     subtitle: diagramSubtitle.value,
     sourceName: selectedSourceName.value,
+    sourceUrl: selectedSourceUrl.value,
     selectedNodeId: selectedNodeId.value,
     message: importMessage.value,
+    exampleId: selectedExampleId.value,
   })
 }
 
@@ -185,11 +210,12 @@ function readPersistedWorkspace(): PersistedWorkspace | undefined {
   }
 }
 
-function persistWorkspace(workspace: PersistedWorkspace): void {
+function persistWorkspace(workspace: PersistedWorkspace): boolean {
   try {
     localStorage.setItem(workspaceStorageKey, JSON.stringify(workspace))
+    return true
   } catch {
-    // Best effort only. The in-memory workspace is still loaded.
+    return false
   }
 }
 
@@ -199,6 +225,39 @@ function clearPersistedWorkspace(): void {
   } catch {
     // Best effort only. The built-in sample is still loaded.
   }
+}
+
+function readExampleFromUrl(): PublicProjectExample | undefined {
+  const exampleId = new URLSearchParams(window.location.search).get("example")
+
+  return publicProjectExamples.find((example) => example.id === exampleId)
+}
+
+function workspaceFromExample(example: PublicProjectExample, storedWorkspace?: PersistedWorkspace): PersistedWorkspace {
+  const defaultSelectedId = firstLayerNodeId(example.graph) ?? example.graph.nodes[0]?.id
+  const selectedId = storedWorkspace?.exampleId === example.id ? storedWorkspace.selectedNodeId ?? defaultSelectedId : defaultSelectedId
+
+  return {
+    graph: example.graph,
+    title: example.title,
+    subtitle: example.subtitle,
+    sourceName: example.sourceName,
+    sourceUrl: example.sourceUrl,
+    selectedNodeId: selectedId,
+    message: `Loaded ${example.graph.nodes.length} code parts and ${example.graph.links.length} links from public ${example.label}.`,
+    exampleId: example.id,
+  }
+}
+
+function replaceUrlState(workspace?: PersistedWorkspace): void {
+  const url = new URL(window.location.href)
+
+  url.search = workspace?.exampleId ? `?example=${encodeURIComponent(workspace.exampleId)}` : ""
+  window.history.replaceState(null, "", url)
+}
+
+function syncDocumentTitle(workspaceTitle: string): void {
+  document.title = workspaceTitle === builtInSourceName ? defaultPageTitle : `${workspaceTitle} · Dimension`
 }
 </script>
 
@@ -226,6 +285,18 @@ function clearPersistedWorkspace(): void {
           <input type="file" webkitdirectory multiple :disabled="isImporting" @change="importProjectFolder" />
         </label>
         <button type="button" :disabled="isImporting" @click="loadBuiltInSample">Load built-in sample</button>
+        <div class="source-import__examples" aria-label="Public project examples">
+          <span>Public examples</span>
+          <button
+            v-for="example in publicProjectExamples"
+            :key="example.id"
+            type="button"
+            :disabled="isImporting"
+            @click="loadPublicProjectExample(example)"
+          >
+            {{ example.label }}
+          </button>
+        </div>
         <p class="source-import__status" :class="`source-import__status--${importStatus}`" aria-live="polite">
           {{ importMessage }}
         </p>
@@ -233,7 +304,12 @@ function clearPersistedWorkspace(): void {
       <dl class="framework-grid" aria-label="Current source graph">
         <div>
           <dt>Source</dt>
-          <dd>{{ selectedSourceName }}</dd>
+          <dd>
+            <a v-if="selectedSourceUrl" :href="selectedSourceUrl" target="_blank" rel="noreferrer">
+              {{ selectedSourceName }}
+            </a>
+            <template v-else>{{ selectedSourceName }}</template>
+          </dd>
         </div>
         <div>
           <dt>Visual shell</dt>

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from "vue"
+import { computed, nextTick, ref } from "vue"
 
 import SpellCanvas from "@/components/SpellCanvas.vue"
 import { usersControllerIndexDiagram } from "@/fixtures/usersControllerIndex"
@@ -86,26 +86,36 @@ async function importSourceFile(event: Event): Promise<void> {
   }
 }
 
-function importProjectFolder(event: Event): void {
+async function importProjectFolder(event: Event): Promise<void> {
   const input = event.target as HTMLInputElement
   const files = input.files
 
   if (!files?.length) return
 
-  const graph = createProjectGraphFromFiles(files)
-  const folderName = graph.nodes[0]?.label ?? "Selected project"
-  const selectedId = graph.nodes[0]?.id
-  const message = `Mapped ${directChildCount(graph, selectedId)} first-layer items from ${folderName}; file contents stayed local.`
+  importStatus.value = "loading"
+  importMessage.value = `Reading ${files.length} selected path${files.length === 1 ? "" : "s"} locally…`
+  await nextFrame()
 
-  setWorkspace({
-    graph,
-    title: folderName,
-    subtitle: "Filename-only project map. This MVP shows the selected folder's direct children only.",
-    sourceName: folderName,
-    selectedNodeId: selectedId,
-    message,
-  })
-  input.value = ""
+  try {
+    const graph = createProjectGraphFromFiles(files)
+    const folderName = graph.nodes[0]?.label ?? "Selected project"
+    const selectedId = graph.nodes[0]?.id
+    const message = `Mapped ${directChildCount(graph, selectedId)} first-layer items from ${folderName}; file contents stayed local.`
+
+    setWorkspace({
+      graph,
+      title: folderName,
+      subtitle: "Filename-only project map. This MVP shows the selected folder's direct children only.",
+      sourceName: folderName,
+      selectedNodeId: selectedId,
+      message,
+    })
+  } catch {
+    importStatus.value = "error"
+    importMessage.value = "Dimension could not map that folder."
+  } finally {
+    input.value = ""
+  }
 }
 
 function selectNode(id: string): void {
@@ -158,6 +168,11 @@ function connectedNodes(diagram: SpellDiagram, node: RuneNode | undefined): Rune
   })
 
   return diagram.nodes.filter((candidate) => connectionIds.has(candidate.id))
+}
+
+async function nextFrame(): Promise<void> {
+  await nextTick()
+  await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
 }
 
 function readPersistedWorkspace(): PersistedWorkspace | undefined {

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,9 +4,16 @@ import { defineConfig } from "vite"
 import vue from "@vitejs/plugin-vue"
 import vueDevTools from "vite-plugin-vue-devtools"
 
+
+const serverApplicationOrigin = process.env.DIMENSION_API_INTERNAL_ORIGIN ?? "http://localhost:3000"
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue(), vueDevTools()],
+  server: {
+    proxy: {
+      "/graphs": serverApplicationOrigin,
+    },
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
## Related links

Part of https://github.com/klondikemarlen/dimension/issues/47
Part of https://github.com/klondikemarlen/dimension/issues/48
Part of https://github.com/klondikemarlen/dimension/issues/49
Part of https://github.com/klondikemarlen/dimension/issues/50
Part of https://github.com/klondikemarlen/dimension/issues/51
Part of https://github.com/klondikemarlen/dimension/issues/54
Part of https://github.com/klondikemarlen/dimension/issues/55
Part of https://github.com/klondikemarlen/dimension/issues/56

## Context

Dimension is pivoting from a hand-coding editor toward a project intelligence workspace for humans and AI agents. This PR adds the MVP import, layered visualizer, project folder map, public example workspaces, visible project-upload progress, and dev-wrapper wiring needed to keep iterating through the normal feature flow.

## Implementation

- Import TypeScript, TSX, and Ruby source files into source graphs, including extensionless upload temp paths.
- Render dense files as layered code maps, starting at the class/controller layer with click-through method drill-down.
- Keep focused method maps centered; move parent and sibling context into a muted side rail with reduced context leylines.
- Import project folders as filename-only first-layer maps without sending file contents to the server.
- Show a visible loading state while large local folder selections are being mapped.
- Add pinned public Icefog controller examples for Travel Authorization, Traditional Knowledge, and ELCC Data Management.
- Store safe public examples in `?example=...`; keep uploaded file/folder workspaces in browser local storage across refresh without leaking local paths into the URL.
- Set page titles for the default workspace and active workspaces.
- Run dev Compose stacks on persisted random host ports and keep PlantUML behind the opt-in `design` profile.
- Add the local feature workflow and update product direction docs.

## Screenshots

N/A — browser QA was performed locally; no repository screenshot artifact was requested.

## Testing instructions

1. Run `npm run type-check` in `web`.
2. Run `npm run build` in `web`.
3. Run `npm run build` in `api`.
4. Run `npm run test:parser` in `api`.
5. Run `ruby -c bin/dev`.
6. Run `dev up -d`; verify only `api` and `web` start by default, then open the web URL from `.dev-ports.env`.
7. Upload `/home/marlen/code/icefoganalytics/wrap/api/src/controllers/workflows-controller.ts`; verify the first layer shows `WorkflowsController` plus method runes and clicking `index` drills into method details.
8. Upload `/home/marlen/code/icefoganalytics/wrap`; verify the status first says `Reading ... selected paths locally…`, controls are disabled while loading, then the folder map reports first-layer items and says file contents stayed local.
9. Click public example `Travel Authorization`, click `buildPolicy`, and verify `buildPolicy` is centered while controller/method context is muted on the side rail.
10. Reload `?example=travel-authorizations`; verify the same public example and selected node restore.
11. Reload after uploading a local file/folder; verify the last local workspace is restored without a local path in the URL.
12. Run `dev down`; verify `dev ps` lists no running services.

## Verification

- PASS `ruby -c bin/dev`
- PASS `web`: `npm run type-check`
- PASS `web`: `npm run build`
- PASS `api`: `npm run build`
- PASS `api`: `npm run test:parser`
- PASS browser QA through `dev up` on persisted random ports
- PASS browser QA for folder loader: uploading `/home/marlen/code/icefoganalytics/wrap` showed `Reading 11463 selected paths locally…`, applied `source-import__status--loading`, disabled 3 controls, then rendered `Mapped 42 first-layer items from wrap; file contents stayed local.`
- PASS browser QA for public example URL state: `?example=travel-authorizations` restored Travel Authorization and selected `buildPolicy` after reload.
- PASS browser QA for local file/folder persistence: uploaded `workflows-controller.ts` and `/home/marlen/code/icefoganalytics/wrap` restored across refresh through local storage.
- PASS browser QA for focused layout: selecting `buildPolicy` rendered the focus at `translate(540 360)`, moved 7 context nodes to `x=175`, and reduced context clutter to 1 context leyline.
- PASS self-review: `LoaderSelfReview` found no findings; residual risk is browser frame throttling in background tabs.

## Learner coverage

Learner coverage: no action — this work came from direct user-directed product exploration rather than a missed automated learner signal.

## Release/install

Not published; repository change only.
