### PR TITLE
Fix local-folder loading and graph inspection layout

### DIFF
--- a/web/src/assets/main.css
+++ b/web/src/assets/main.css
@@ -10,7 +10,13 @@
   display: grid;
   gap: clamp(1.25rem, 3vw, 3rem);
   grid-template-columns: minmax(17rem, 0.3fr) minmax(0, 1fr);
-  align-items: stretch;
+  align-items: start;
+}
+
+.inspection-pane {
+  min-width: 0;
+  display: grid;
+  gap: 1rem;
 }
 
 .hero-panel,
@@ -40,9 +46,9 @@
 h1 {
   margin: 0;
   color: var(--color-heading);
-  font-family: var(--font-display);
-  font-size: clamp(1.8rem, 3vw, 3rem);
-  line-height: 1;
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: clamp(1.15rem, 2.1vw, 2rem);
+  line-height: 1.1;
   overflow-wrap: anywhere;
 }
 
@@ -200,6 +206,10 @@ h1 {
   overflow-wrap: anywhere;
 }
 
+.inspection-pane .graph-details {
+  margin: 0;
+}
+
 .graph-details h2 {
   margin: 0;
   color: var(--color-heading);
@@ -235,6 +245,17 @@ h1 {
   overflow: hidden;
   display: flex;
   flex-direction: column;
+}
+
+.spell-canvas::before {
+  content: "graph://dimension";
+  padding: 0.7rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  background: rgba(31, 21, 12, 0.88);
+  color: var(--color-parchment);
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", monospace;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
 }
 
 .spell-canvas svg {

--- a/web/src/components/SpellCanvas.vue
+++ b/web/src/components/SpellCanvas.vue
@@ -78,7 +78,7 @@ function nodeLabelLines(label: string): string[] {
 
 <template>
   <figure class="spell-canvas" :aria-label="diagram.title">
-    <svg viewBox="0 0 1080 720" role="img">
+    <svg viewBox="0 0 1080 720" preserveAspectRatio="xMidYMin meet" role="img">
       <title>{{ diagram.title }}</title>
       <desc>{{ diagram.subtitle }}</desc>
 

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -128,17 +128,25 @@ async function importSourceFile(event: Event): Promise<void> {
 }
 
 async function openLocalProject(): Promise<void> {
+  importStatus.value = "loading"
+  importMessage.value = "Choose a local folder. Dimension will skip generated folders and parse supported code files."
+
   const pickerWindow = window as WindowWithDirectoryPicker
 
   if (!pickerWindow.showDirectoryPicker) {
-    projectFolderInput.value?.click()
+    const input = projectFolderInput.value
+
+    if (!input) return
+
+    input.value = ""
+    input.addEventListener("cancel", resetLocalProjectSelection, { once: true })
+    input.click()
     return
   }
 
   try {
     const directory = await pickerWindow.showDirectoryPicker()
 
-    importStatus.value = "loading"
     importMessage.value = `Scanning ${directory.name}; generated folders are skipped before supported code files are sent to the parser…`
     await nextFrame()
 
@@ -160,7 +168,12 @@ async function importProjectFolder(event: Event): Promise<void> {
   const input = event.target as HTMLInputElement
   const files = input.files
 
-  if (!files?.length) return
+  input.removeEventListener("cancel", resetLocalProjectSelection)
+
+  if (!files?.length) {
+    resetLocalProjectSelection()
+    return
+  }
 
   try {
     await importProjectFiles(projectNameForFiles(files), projectFilesFromInput(files))
@@ -169,11 +182,19 @@ async function importProjectFolder(event: Event): Promise<void> {
   }
 }
 
+function resetLocalProjectSelection(): void {
+  importStatus.value = "idle"
+  importMessage.value = defaultImportMessage
+}
+
 async function importProjectFiles(rootName: string, projectFiles: LocalProjectFile[]): Promise<void> {
   try {
+    importStatus.value = "loading"
+    importMessage.value = `Preparing ${projectFiles.length} selected local path${projectFiles.length === 1 ? "" : "s"}…`
+    await nextFrame()
+
     const plan = planProjectImport(projectFiles)
 
-    importStatus.value = "loading"
     importMessage.value = `Reading ${plan.files.length} local path${plan.files.length === 1 ? "" : "s"} from ${rootName}; sending ${plan.parseableCount} supported code file${plan.parseableCount === 1 ? "" : "s"} to the parser${plan.skippedCount ? ` and skipping ${plan.skippedCount} generated path${plan.skippedCount === 1 ? "" : "s"}` : ""}…`
     await nextFrame()
 
@@ -386,7 +407,6 @@ function syncDocumentTitle(workspaceTitle: string): void {
             type="file"
             webkitdirectory
             multiple
-            :disabled="isImporting"
             @change="importProjectFolder"
           />
         </div>
@@ -423,6 +443,10 @@ function syncDocumentTitle(workspaceTitle: string): void {
           <dd>{{ graphLinkCount }}</dd>
         </div>
       </dl>
+    </section>
+
+    <section class="inspection-pane" aria-label="Dimension graph inspection">
+      <SpellCanvas :diagram="currentDiagram" @select-node="selectNode" />
       <section class="graph-details" aria-label="Selected rune details">
         <p class="eyebrow">Navigation</p>
         <h2>{{ selectedNode?.label ?? "Click a rune" }}</h2>
@@ -445,7 +469,5 @@ function syncDocumentTitle(workspaceTitle: string): void {
         </div>
       </section>
     </section>
-
-    <SpellCanvas :diagram="currentDiagram" @select-node="selectNode" />
   </main>
 </template>


### PR DESCRIPTION
Fixes https://github.com/klondikemarlen/dimension/issues/59

Relates to:

- https://github.com/klondikemarlen/dimension/issues/48
- https://github.com/klondikemarlen/dimension/issues/57

# Context

Manual QA reported that `Open local folder` appeared inactive, the main graph started too low in the viewport, and selected-rune details competed with source controls in the side rail.

# Implementation

- Shows picker/loading status before native or fallback folder selection work starts.
- Keeps the hidden `webkitdirectory` fallback selectable while the native picker is active, with cancel cleanup restoring idle state.
- Moves selected-rune navigation below the graph and top-aligns the workspace so the canvas starts in view.
- Gives the graph shell a more code-editor-like title bar and top-biased SVG layout.

# Screenshots

Browser QA screenshot captured locally at `/tmp/omp-sshots-1538a18701decd1a.webp`; not uploaded to the PR because the local browser tool returned a session file path only.

# Testing Instructions

1. Run `npm run type-check` in `web/`.
2. Run `npm run build` in `web/` with `VITE_SERVER_APPLICATION_ORIGIN=http://127.0.0.1:38791`.
3. Run `npm run test:parser` in `api/`.
4. Run `npm run build` in `api/`.
5. Start the app with `COMPOSE_PROFILES= ./bin/dev up -d` and open `http://127.0.0.1:36925/`.
6. Click `Open local folder`; expected: status changes immediately while a folder is being chosen/scanned, the canvas starts at the top of the page, and navigation details render below the graph.
