### PR TITLE
Show local project preview before code mining

### DIFF
--- a/web/src/assets/main.css
+++ b/web/src/assets/main.css
@@ -64,7 +64,6 @@ h1 {
   gap: 0.75rem;
 }
 
-.source-import label,
 .source-import__field {
   display: grid;
   gap: 0.45rem;
@@ -72,7 +71,29 @@ h1 {
   font-weight: 700;
 }
 
-.source-import input {
+.source-import__control {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.source-import__button,
+.source-import button {
+  justify-self: start;
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-parchment);
+  color: var(--color-heading);
+  cursor: pointer;
+  padding: 0.65rem 1rem;
+  font: inherit;
+  font-weight: 700;
+  line-height: 1;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.42);
+}
+
+.source-import__field > input:not(.source-import__hidden-input) {
   width: 100%;
   border: 1px solid var(--color-border);
   border-radius: 14px;
@@ -81,7 +102,25 @@ h1 {
   padding: 0.75rem;
 }
 
-.source-import input:disabled {
+.source-import__field > input:not(.source-import__hidden-input):disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+
+.source-import__field:focus-within .source-import__button,
+.source-import button:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.source-import__hint {
+  color: var(--color-muted);
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.source-import button:disabled,
+.source-import__field--disabled .source-import__button {
   cursor: progress;
   opacity: 0.7;
 }
@@ -92,31 +131,6 @@ h1 {
   height: 1px;
   opacity: 0;
   pointer-events: none;
-}
-
-.source-import button {
-  justify-self: start;
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  background: var(--color-parchment);
-  color: var(--color-heading);
-  cursor: pointer;
-  padding: 0.65rem 1rem;
-  font-weight: 700;
-}
-
-.source-import button:disabled {
-  cursor: progress;
-  opacity: 0.7;
-}
-
-.source-import input::file-selector-button {
-  border: 1px solid var(--color-border);
-  border-radius: 999px;
-  background: var(--color-parchment);
-  color: var(--color-heading);
-  cursor: pointer;
-  font-weight: 700;
 }
 
 .source-import__examples {

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -147,7 +147,13 @@ async function openLocalProject(): Promise<void> {
   try {
     const directory = await pickerWindow.showDirectoryPicker()
 
-    importMessage.value = `Scanning ${directory.name}; generated folders are skipped before supported code files are sent to the parser…`
+    importMessage.value = `Listing top-level files and folders in ${directory.name}…`
+    await nextFrame()
+
+    const previewGraph = await createTopLevelProjectGraphFromDirectory(directory)
+    showLocalProjectPreview(directory.name, previewGraph)
+
+    importMessage.value = `Data-mining ${directory.name}; generated folders are skipped before supported code files are parsed…`
     await nextFrame()
 
     const projectFiles = await projectFilesFromDirectory(directory)
@@ -176,7 +182,14 @@ async function importProjectFolder(event: Event): Promise<void> {
   }
 
   try {
-    await importProjectFiles(projectNameForFiles(files), projectFilesFromInput(files))
+    const rootName = projectNameForFiles(files)
+    const projectFiles = projectFilesFromInput(files)
+
+    showLocalProjectPreview(rootName, createTopLevelProjectGraphFromFiles(rootName, projectFiles))
+    importMessage.value = `Data-mining ${rootName}; generated folders are skipped before supported code files are parsed…`
+    await nextFrame()
+
+    await importProjectFiles(rootName, projectFiles)
   } finally {
     input.value = ""
   }
@@ -195,7 +208,7 @@ async function importProjectFiles(rootName: string, projectFiles: LocalProjectFi
 
     const plan = planProjectImport(projectFiles)
 
-    importMessage.value = `Reading ${plan.files.length} local path${plan.files.length === 1 ? "" : "s"} from ${rootName}; sending ${plan.parseableCount} supported code file${plan.parseableCount === 1 ? "" : "s"} to the parser${plan.skippedCount ? ` and skipping ${plan.skippedCount} generated path${plan.skippedCount === 1 ? "" : "s"}` : ""}…`
+    importMessage.value = `Data-mining ${rootName}; scanning ${plan.files.length} local path${plan.files.length === 1 ? "" : "s"}, parsing ${plan.parseableCount} supported code file${plan.parseableCount === 1 ? "" : "s"}${plan.skippedCount ? `, and skipping ${plan.skippedCount} generated path${plan.skippedCount === 1 ? "" : "s"}` : ""}…`
     await nextFrame()
 
     const graph = await createGraphFromProjectFiles(rootName, plan.files)
@@ -215,6 +228,67 @@ async function importProjectFiles(rootName: string, projectFiles: LocalProjectFi
     importStatus.value = "error"
     importMessage.value = error instanceof Error ? error.message : "Dimension could not map that local folder."
   }
+}
+
+function showLocalProjectPreview(rootName: string, graph: SourceGraph): void {
+  const selectedId = graph.nodes[0]?.id
+  const message = `Listed ${directChildCount(graph, selectedId)} top-level item${directChildCount(graph, selectedId) === 1 ? "" : "s"} from ${rootName}; data-mining supported code files…`
+
+  sourceGraph.value = graph
+  diagramTitle.value = rootName
+  diagramSubtitle.value = "Local project map with top-level files and folders while Dimension data-mines code relationships."
+  selectedSourceName.value = rootName
+  selectedSourceUrl.value = undefined
+  selectedNodeId.value = selectedId
+  selectedExampleId.value = undefined
+  replaceUrlState()
+  syncDocumentTitle(rootName)
+  importStatus.value = "loading"
+  importMessage.value = message
+}
+
+async function createTopLevelProjectGraphFromDirectory(directory: LocalDirectoryHandle): Promise<SourceGraph> {
+  const rootName = directory.name.trim() || "Selected project"
+  const graph = createProjectRootGraph(rootName)
+
+  for await (const entry of directory.values()) {
+    addTopLevelProjectNode(graph, rootName, entry.name, entry.kind === "directory" ? "folder" : "file")
+  }
+
+  return graph
+}
+
+function createTopLevelProjectGraphFromFiles(rootName: string, projectFiles: LocalProjectFile[]): SourceGraph {
+  const graph = createProjectRootGraph(rootName)
+  const topLevelPaths = new Map<string, "file" | "folder">()
+
+  projectFiles.forEach((projectFile) => {
+    const [firstSegment, secondSegment] = projectFile.path.split("/").filter(Boolean)
+
+    if (!firstSegment) return
+
+    topLevelPaths.set(firstSegment, secondSegment ? "folder" : "file")
+  })
+
+  topLevelPaths.forEach((type, name) => addTopLevelProjectNode(graph, rootName, name, type))
+
+  return graph
+}
+
+function createProjectRootGraph(rootName: string): SourceGraph {
+  const safeRootName = rootName.trim() || "Selected project"
+
+  return {
+    nodes: [{ id: `folder:${safeRootName}`, label: safeRootName, type: "folder" }],
+    links: [],
+  }
+}
+
+function addTopLevelProjectNode(graph: SourceGraph, rootName: string, name: string, type: "file" | "folder"): void {
+  const id = `${type}:${rootName}/${name}`
+
+  graph.nodes.push({ id, label: name, type })
+  graph.links.push({ source: graph.nodes[0].id, target: id })
 }
 
 async function projectFilesFromDirectory(directory: LocalDirectoryHandle, prefix = ""): Promise<LocalProjectFile[]> {
@@ -389,9 +463,14 @@ function syncDocumentTitle(workspaceTitle: string): void {
         <p class="source-import__status" :class="`source-import__status--${importStatus}`" aria-live="polite">
           {{ importMessage }}
         </p>
-        <label>
+        <label class="source-import__field" :class="{ 'source-import__field--disabled': isImporting }">
           <span>Source file</span>
+          <span class="source-import__control">
+            <span class="source-import__button">Browse source file</span>
+            <span class="source-import__hint">TypeScript or Ruby</span>
+          </span>
           <input
+            class="source-import__hidden-input"
             type="file"
             accept=".ts,.tsx,.rb,text/typescript,text/x-ruby"
             :disabled="isImporting"


### PR DESCRIPTION
Fixes https://github.com/klondikemarlen/dimension/issues/61

Relates to:

- https://github.com/klondikemarlen/dimension/issues/59

# Context

User QA flagged the source import area as visually inconsistent: the file input used native browser chrome while local-folder and sample actions used large pill controls. Follow-up QA clarified that `Open local folder` should also render the first layer of the selected project immediately, then stay visibly loading while Dimension mines supported files for relationships.

# Implementation

- Replaces the visible native file chooser with an accessible custom source-file control matching the existing pill button language.
- Preserves keyboard focus and disabled/loading styling for source import controls.
- Renders a transient top-level local-project preview from native `showDirectoryPicker()` entries or fallback `webkitdirectory` file paths.
- Keeps generated-looking top-level folders visible in the preview, while still skipping generated folders during the data-mining/parser pass.
- Avoids persisting the transient preview; only completed import graphs are saved for reload.

# Screenshots

N/A — browser QA was inspected through DOM state and viewport overflow checks; no persistent screenshot artifact was requested.

# Self-review

PASS. Reviewed the scoped diff for `HomeView.vue` and `main.css`; no actionable findings. The preview graph is intentionally transient and final persistence remains limited to completed imports.

# Testing Instructions

1. Run `npm run type-check` in `web/`.
2. Run `npm run build` in `web/` with `VITE_SERVER_APPLICATION_ORIGIN=http://127.0.0.1:38791`.
3. Browser QA at `http://127.0.0.1:36925/` with a stubbed directory picker whose project contains `README.md`, `src/`, and `node_modules/`: click `Open local folder`; expected: `README.md`, `src`, and `node_modules` render immediately, status says Dimension is data-mining, and the final graph replaces the preview after parsing supported files.
4. Browser QA at 360px viewport: expected no horizontal overflow and the first three source controls share pill styling.
