### PR TITLE
Make local source selection consistent

### DIFF
--- a/api/src/controllers/graphs-controller.ts
+++ b/api/src/controllers/graphs-controller.ts
@@ -1,32 +1,7 @@
 import { unlink } from "node:fs/promises"
 import { type Request, type Response } from "express"
 
-import createService, { createProjectService, type ProjectSourceFile } from "@/services/graphs/create-service"
-
-export async function create(req: Request, res: Response): Promise<void> {
-  if (!req.file) {
-    res.status(400).json({
-      message: "No file uploaded",
-    })
-    return
-  }
-
-  const uploadPath = req.file.path
-
-  try {
-    const graph = createService(uploadPath, req.file.originalname)
-
-    res.json({
-      graph,
-    })
-  } catch {
-    res.status(422).json({
-      message: "The source importer could not parse that file.",
-    })
-  } finally {
-    await unlink(uploadPath).catch(() => undefined)
-  }
-}
+import { createProjectService, type ProjectSourceFile } from "@/services/graphs/create-service"
 
 export async function createProject(req: Request, res: Response): Promise<void> {
   const uploadedFiles = Array.isArray(req.files) ? req.files : []
@@ -62,6 +37,5 @@ function parseStringArray(value: unknown): string[] {
 }
 
 export default {
-  create,
   createProject,
 }

--- a/api/src/router.ts
+++ b/api/src/router.ts
@@ -10,7 +10,6 @@ router.get("/", (_req: Request, res: Response) => {
   res.send("Hello World!")
 })
 
-router.post("/graphs", uploadMiddleware.single("file"), GraphsController.create)
 router.post("/graphs/project", uploadMiddleware.array("files"), GraphsController.createProject)
 
 export default router

--- a/web/package.json
+++ b/web/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview",
     "build-only": "vite build",
     "type-check": "vue-tsc --build",
+    "test:folder": "node --experimental-strip-types src/services/__tests__/project-folder-service.spec.ts",
     "lint": "eslint . --fix",
     "format": "prettier --write src/"
   },

--- a/web/src/services/__tests__/project-folder-service.spec.ts
+++ b/web/src/services/__tests__/project-folder-service.spec.ts
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict"
+
+import {
+  createProjectPreviewGraphFromFiles,
+  planProjectImport,
+  projectFilesFromInput,
+  projectNameForFiles,
+  type LocalProjectFile,
+} from "../project-folder-service.ts"
+
+function projectFile(path: string, size = 1): File {
+  const parts = path.split("/")
+  const name = parts[parts.length - 1] ?? path
+  const file = new File(["x".repeat(size)], name, { type: "text/typescript" })
+
+  Object.defineProperty(file, "webkitRelativePath", { value: path })
+
+  return file
+}
+
+function fileList(paths: string[]): FileList {
+  const files = paths.map((path) => projectFile(path))
+
+  Object.defineProperty(files, "item", { value: (index: number) => files[index] })
+
+  return files as unknown as FileList
+}
+
+const selectedFiles = fileList([
+  "dimension-folder-input-qa/README.md",
+  "dimension-folder-input-qa/src/app.ts",
+  "dimension-folder-input-qa/node_modules/pkg/ignored.ts",
+])
+
+assert.equal(projectNameForFiles(selectedFiles), "dimension-folder-input-qa")
+
+const projectFiles = projectFilesFromInput(selectedFiles)
+assert.deepEqual(
+  projectFiles.map((file) => file.path),
+  ["README.md", "src/app.ts", "node_modules/pkg/ignored.ts"],
+)
+
+const previewGraph = createProjectPreviewGraphFromFiles("dimension-folder-input-qa", projectFiles)
+assert.deepEqual(
+  previewGraph.nodes.map((node) => `${node.type}:${node.label}`),
+  ["folder:dimension-folder-input-qa", "file:README.md", "folder:src", "folder:node_modules"],
+)
+assert.deepEqual(
+  previewGraph.links.map((link) => link.target),
+  [
+    "file:dimension-folder-input-qa/README.md",
+    "folder:dimension-folder-input-qa/src",
+    "folder:dimension-folder-input-qa/node_modules",
+  ],
+)
+
+const importPlan = planProjectImport(projectFiles as LocalProjectFile[])
+assert.deepEqual(
+  importPlan.files.map((file) => file.path),
+  ["README.md", "src/app.ts"],
+)
+assert.equal(importPlan.skippedCount, 1)
+assert.equal(importPlan.parseableCount, 1)

--- a/web/src/services/__tests__/project-folder-service.spec.ts
+++ b/web/src/services/__tests__/project-folder-service.spec.ts
@@ -61,3 +61,11 @@ assert.deepEqual(
 )
 assert.equal(importPlan.skippedCount, 1)
 assert.equal(importPlan.parseableCount, 1)
+
+const singleSourceGraph = createProjectPreviewGraphFromFiles("Selected source", [
+  { file: projectFile("app.ts"), path: "app.ts" },
+])
+assert.deepEqual(
+  singleSourceGraph.nodes.map((node) => `${node.type}:${node.label}`),
+  ["folder:Selected source", "file:app.ts"],
+)

--- a/web/src/services/graph-import-service.ts
+++ b/web/src/services/graph-import-service.ts
@@ -1,22 +1,5 @@
 import type { SourceGraph } from "@/types/source-graph"
-
-export interface LocalProjectFile {
-  file: File
-  path: string
-}
-
-const PARSEABLE_EXTENSIONS = new Set([".js", ".jsx", ".rb", ".ts", ".tsx"])
-const GENERATED_PATH_SEGMENTS = new Set([".git", ".vite", "coverage", "dist", "node_modules"])
-const MAX_PROJECT_PATHS = 15000
-const MAX_PARSEABLE_FILES = 500
-const MAX_PARSEABLE_FILE_BYTES = 512 * 1024
-
-export interface ProjectImportPlan {
-  files: LocalProjectFile[]
-  skippedCount: number
-  parseableCount: number
-}
-
+import { planProjectImport, type LocalProjectFile } from "@/services/project-folder-service"
 
 const serverApplicationOrigin = import.meta.env.VITE_SERVER_APPLICATION_ORIGIN?.replace(/\/$/, "") ?? ""
 
@@ -47,31 +30,10 @@ export async function createGraphFromSourceFile(file: File): Promise<SourceGraph
   return responseBody.graph
 }
 
-export function planProjectImport(projectFiles: LocalProjectFile[]): ProjectImportPlan {
-  const files = projectFiles.filter((projectFile) => !isGeneratedPath(projectFile.path))
-  const parseableFiles = files.filter(isParseableProjectFile)
-
-  if (files.length > MAX_PROJECT_PATHS) {
-    throw new Error(`Dimension can map up to ${MAX_PROJECT_PATHS} project paths at once; ${files.length} were selected.`)
-  }
-
-  if (parseableFiles.length > MAX_PARSEABLE_FILES) {
-    throw new Error(
-      `Dimension can parse up to ${MAX_PARSEABLE_FILES} source files at once; ${parseableFiles.length} were selected after generated folders were skipped.`,
-    )
-  }
-
-  return {
-    files,
-    skippedCount: projectFiles.length - files.length,
-    parseableCount: parseableFiles.length,
-  }
-}
-
 export async function createGraphFromProjectFiles(rootName: string, projectFiles: LocalProjectFile[]): Promise<SourceGraph> {
   const plan = planProjectImport(projectFiles)
   const paths = plan.files.map((projectFile) => projectFile.path)
-  const parseableFiles = plan.files.filter(isParseableProjectFile)
+  const parseableFiles = plan.parseableFiles
   const formData = new FormData()
   formData.append("rootName", rootName)
   formData.append("paths", JSON.stringify(paths))
@@ -94,20 +56,6 @@ export async function createGraphFromProjectFiles(rootName: string, projectFiles
   }
 
   return responseBody.graph
-}
-
-function isParseableProjectFile(projectFile: LocalProjectFile): boolean {
-  return PARSEABLE_EXTENSIONS.has(extensionFor(projectFile.path)) && projectFile.file.size <= MAX_PARSEABLE_FILE_BYTES
-}
-
-function isGeneratedPath(path: string): boolean {
-  return path.split(/[\\/]+/).some((part) => GENERATED_PATH_SEGMENTS.has(part))
-}
-
-function extensionFor(path: string): string {
-  const match = /\.[^.\\/]+$/.exec(path)
-
-  return match?.[0] ?? ""
 }
 
 async function readGraphImportResponse(response: Response): Promise<GraphImportResponse> {

--- a/web/src/services/graph-import-service.ts
+++ b/web/src/services/graph-import-service.ts
@@ -8,28 +8,6 @@ interface GraphImportResponse {
   message?: string
 }
 
-export async function createGraphFromSourceFile(file: File): Promise<SourceGraph> {
-  const formData = new FormData()
-  formData.append("file", file)
-
-  const response = await fetch(`${serverApplicationOrigin}/graphs`, {
-    method: "POST",
-    body: formData,
-  })
-
-  const responseBody = await readGraphImportResponse(response)
-
-  if (!response.ok) {
-    throw new Error(responseBody.message ?? `The source importer rejected ${file.name}.`)
-  }
-
-  if (!responseBody.graph) {
-    throw new Error("The source importer did not return a graph.")
-  }
-
-  return responseBody.graph
-}
-
 export async function createGraphFromProjectFiles(rootName: string, projectFiles: LocalProjectFile[]): Promise<SourceGraph> {
   const plan = planProjectImport(projectFiles)
   const paths = plan.files.map((projectFile) => projectFile.path)

--- a/web/src/services/project-folder-service.ts
+++ b/web/src/services/project-folder-service.ts
@@ -1,0 +1,114 @@
+import type { SourceGraph } from "../types/source-graph"
+
+export interface LocalProjectFile {
+  file: File
+  path: string
+}
+
+export interface ProjectPreviewEntry {
+  name: string
+  type: "file" | "folder"
+}
+
+const PARSEABLE_EXTENSIONS = new Set([".js", ".jsx", ".rb", ".ts", ".tsx"])
+const GENERATED_PATH_SEGMENTS = new Set([".git", ".vite", "coverage", "dist", "node_modules"])
+const MAX_PROJECT_PATHS = 15000
+const MAX_PARSEABLE_FILES = 500
+const MAX_PARSEABLE_FILE_BYTES = 512 * 1024
+
+export interface ProjectImportPlan {
+  files: LocalProjectFile[]
+  parseableFiles: LocalProjectFile[]
+  skippedCount: number
+  parseableCount: number
+}
+
+export function planProjectImport(projectFiles: LocalProjectFile[]): ProjectImportPlan {
+  const files = projectFiles.filter((projectFile) => !isGeneratedPath(projectFile.path))
+  const parseableFiles = files.filter(isParseableProjectFile)
+
+  if (files.length > MAX_PROJECT_PATHS) {
+    throw new Error(`Dimension can map up to ${MAX_PROJECT_PATHS} project paths at once; ${files.length} were selected.`)
+  }
+
+  if (parseableFiles.length > MAX_PARSEABLE_FILES) {
+    throw new Error(
+      `Dimension can parse up to ${MAX_PARSEABLE_FILES} source files at once; ${parseableFiles.length} were selected after generated folders were skipped.`,
+    )
+  }
+
+  return {
+    files,
+    parseableFiles,
+    skippedCount: projectFiles.length - files.length,
+    parseableCount: parseableFiles.length,
+  }
+}
+
+export function projectFilesFromInput(files: FileList): LocalProjectFile[] {
+  return Array.from(files).map((file) => {
+    const relativePath = file.webkitRelativePath || file.name
+    const parts = relativePath.split("/").filter(Boolean)
+
+    return {
+      file,
+      path: parts.slice(1).join("/") || parts[0] || file.name,
+    }
+  })
+}
+
+export function projectNameForFiles(files: FileList): string {
+  const relativePath = files[0]?.webkitRelativePath
+  const rootName = relativePath?.split("/").filter(Boolean)[0]
+
+  return rootName || "Selected project"
+}
+
+export function createProjectPreviewGraphFromFiles(rootName: string, projectFiles: LocalProjectFile[]): SourceGraph {
+  const entries = new Map<string, ProjectPreviewEntry>()
+
+  projectFiles.forEach((projectFile) => {
+    const [firstSegment, secondSegment] = projectFile.path.split("/").filter(Boolean)
+
+    if (!firstSegment) return
+
+    entries.set(firstSegment, {
+      name: firstSegment,
+      type: secondSegment ? "folder" : "file",
+    })
+  })
+
+  return createProjectPreviewGraph(rootName, entries.values())
+}
+
+export function createProjectPreviewGraph(rootName: string, entries: Iterable<ProjectPreviewEntry>): SourceGraph {
+  const safeRootName = rootName.trim() || "Selected project"
+  const rootId = `folder:${safeRootName}`
+  const graph: SourceGraph = {
+    nodes: [{ id: rootId, label: safeRootName, type: "folder" }],
+    links: [],
+  }
+
+  for (const entry of entries) {
+    const id = `${entry.type}:${safeRootName}/${entry.name}`
+
+    graph.nodes.push({ id, label: entry.name, type: entry.type })
+    graph.links.push({ source: rootId, target: id })
+  }
+
+  return graph
+}
+
+function isParseableProjectFile(projectFile: LocalProjectFile): boolean {
+  return PARSEABLE_EXTENSIONS.has(extensionFor(projectFile.path)) && projectFile.file.size <= MAX_PARSEABLE_FILE_BYTES
+}
+
+function isGeneratedPath(path: string): boolean {
+  return path.split(/[\\/]+/).some((part) => GENERATED_PATH_SEGMENTS.has(part))
+}
+
+function extensionFor(path: string): string {
+  const match = /\.[^.\\/]+$/.exec(path)
+
+  return match?.[0] ?? ""
+}

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -4,7 +4,7 @@ import { computed, nextTick, ref } from "vue"
 import SpellCanvas from "@/components/SpellCanvas.vue"
 import { usersControllerIndexDiagram } from "@/fixtures/usersControllerIndex"
 import { publicProjectExamples, type PublicProjectExample } from "@/fixtures/publicProjectExamples"
-import { createGraphFromProjectFiles, createGraphFromSourceFile } from "@/services/graph-import-service"
+import { createGraphFromProjectFiles } from "@/services/graph-import-service"
 import {
   createProjectPreviewGraphFromFiles,
   planProjectImport,
@@ -87,26 +87,19 @@ async function importSourceFile(event: Event): Promise<void> {
 
   if (!sourceFile) return
 
-  importStatus.value = "loading"
-  importMessage.value = `Parsing ${sourceFile.name} through the server importer…`
+  const rootName = "Selected source"
+  const sourceName = sourceFile.name
+  const projectFiles: LocalProjectFile[] = [{ file: sourceFile, path: sourceFile.name }]
 
   try {
-    const graph = await createGraphFromSourceFile(sourceFile)
-    const selectedId = firstLayerNodeId(graph) ?? graph.nodes[0]?.id
-    const message = `Mapped ${graph.nodes.length} code parts and ${graph.links.length} links from ${sourceFile.name}.`
+    showLocalProjectPreview(rootName, createProjectPreviewGraphFromFiles(rootName, projectFiles), sourceName)
+    importMessage.value = `Data-mining ${sourceName}; parsing 1 supported code file…`
+    await nextFrame()
 
-    setWorkspace({
-      graph,
-      title: sourceFile.name,
-      subtitle: "High-level code map imported from the server parser.",
-      sourceName: sourceFile.name,
-      sourceUrl: undefined,
-      selectedNodeId: selectedId,
-      message,
-    })
+    await importProjectFiles(rootName, projectFiles, sourceName)
   } catch (error) {
     importStatus.value = "error"
-    importMessage.value = error instanceof Error ? error.message : "The source importer could not render that file."
+    importMessage.value = error instanceof Error ? error.message : "Dimension could not map that source file."
   } finally {
     input.value = ""
   }
@@ -148,49 +141,48 @@ function resetLocalProjectSelection(): void {
   importMessage.value = defaultImportMessage
 }
 
-async function importProjectFiles(rootName: string, projectFiles: LocalProjectFile[]): Promise<void> {
+async function importProjectFiles(rootName: string, projectFiles: LocalProjectFile[], sourceName = rootName): Promise<void> {
   try {
     importStatus.value = "loading"
     importMessage.value = `Preparing ${projectFiles.length} selected local path${projectFiles.length === 1 ? "" : "s"}…`
     await nextFrame()
 
     const plan = planProjectImport(projectFiles)
-
-    importMessage.value = `Data-mining ${rootName}; scanning ${plan.files.length} local path${plan.files.length === 1 ? "" : "s"}, parsing ${plan.parseableCount} supported code file${plan.parseableCount === 1 ? "" : "s"}${plan.skippedCount ? `, and skipping ${plan.skippedCount} generated path${plan.skippedCount === 1 ? "" : "s"}` : ""}…`
+    importMessage.value = `Data-mining ${sourceName}; scanning ${plan.files.length} local path${plan.files.length === 1 ? "" : "s"}, parsing ${plan.parseableCount} supported code file${plan.parseableCount === 1 ? "" : "s"}${plan.skippedCount ? `, and skipping ${plan.skippedCount} generated path${plan.skippedCount === 1 ? "" : "s"}` : ""}…`
     await nextFrame()
 
     const graph = await createGraphFromProjectFiles(rootName, plan.files)
     const selectedId = graph.nodes[0]?.id
-    const message = `Mapped ${directChildCount(graph, selectedId)} first-layer items from ${rootName}; folder/file nodes are kept and supported code files were parsed.`
+    const message = `Mapped ${directChildCount(graph, selectedId)} first-layer item${directChildCount(graph, selectedId) === 1 ? "" : "s"} from ${sourceName}; folder/file nodes are kept and supported code files were parsed.`
 
     setWorkspace({
       graph,
-      title: rootName,
-      subtitle: "Local project map with folder/file hierarchy and parsed TypeScript, JavaScript, and Ruby code beneath files.",
-      sourceName: rootName,
+      title: sourceName,
+      subtitle: "Source map with file/folder hierarchy and parsed TypeScript, JavaScript, and Ruby code beneath files.",
+      sourceName,
       sourceUrl: undefined,
       selectedNodeId: selectedId,
       message,
     })
   } catch (error) {
     importStatus.value = "error"
-    importMessage.value = error instanceof Error ? error.message : "Dimension could not map that local folder."
+    importMessage.value = error instanceof Error ? error.message : `Dimension could not map ${sourceName}.`
   }
 }
 
-function showLocalProjectPreview(rootName: string, graph: SourceGraph): void {
+function showLocalProjectPreview(rootName: string, graph: SourceGraph, sourceName = rootName): void {
   const selectedId = graph.nodes[0]?.id
-  const message = `Listed ${directChildCount(graph, selectedId)} top-level item${directChildCount(graph, selectedId) === 1 ? "" : "s"} from ${rootName}; data-mining supported code files…`
+  const message = `Listed ${directChildCount(graph, selectedId)} top-level item${directChildCount(graph, selectedId) === 1 ? "" : "s"} from ${sourceName}; data-mining supported code files…`
 
   sourceGraph.value = graph
-  diagramTitle.value = rootName
-  diagramSubtitle.value = "Local project map with top-level files and folders while Dimension data-mines code relationships."
-  selectedSourceName.value = rootName
+  diagramTitle.value = sourceName
+  diagramSubtitle.value = "Source map with top-level files and folders while Dimension data-mines code relationships."
+  selectedSourceName.value = sourceName
   selectedSourceUrl.value = undefined
   selectedNodeId.value = selectedId
   selectedExampleId.value = undefined
   replaceUrlState()
-  syncDocumentTitle(rootName)
+  syncDocumentTitle(sourceName)
   importStatus.value = "loading"
   importMessage.value = message
 }
@@ -334,12 +326,12 @@ function syncDocumentTitle(workspaceTitle: string): void {
           <span>Source file</span>
           <span class="source-import__control">
             <span class="source-import__button">Browse source file</span>
-            <span class="source-import__hint">TypeScript or Ruby</span>
+            <span class="source-import__hint">JS, TS, or Ruby</span>
           </span>
           <input
             class="source-import__hidden-input"
             type="file"
-            accept=".ts,.tsx,.rb,text/typescript,text/x-ruby"
+            accept=".js,.jsx,.ts,.tsx,.rb,text/javascript,text/typescript,text/x-ruby"
             :disabled="isImporting"
             @change="importSourceFile"
           />

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -4,12 +4,14 @@ import { computed, nextTick, ref } from "vue"
 import SpellCanvas from "@/components/SpellCanvas.vue"
 import { usersControllerIndexDiagram } from "@/fixtures/usersControllerIndex"
 import { publicProjectExamples, type PublicProjectExample } from "@/fixtures/publicProjectExamples"
+import { createGraphFromProjectFiles, createGraphFromSourceFile } from "@/services/graph-import-service"
 import {
-  createGraphFromProjectFiles,
-  createGraphFromSourceFile,
+  createProjectPreviewGraphFromFiles,
   planProjectImport,
+  projectFilesFromInput,
+  projectNameForFiles,
   type LocalProjectFile,
-} from "@/services/graph-import-service"
+} from "@/services/project-folder-service"
 import { createSpellDiagramFromSourceGraph } from "@/services/spell-diagram-adapter"
 import type { SourceGraph } from "@/types/source-graph"
 import type { RuneNode, SpellDiagram } from "@/types/spell-diagram"
@@ -18,7 +20,6 @@ const builtInSourceName = "Built-in controller fixture"
 const defaultImportMessage = "Choose a source file for layered code review, or open a local folder for a project map."
 const builtInSubtitle = "Controller fixture for reviewing project organization across method, policy, query, and response layers."
 const workspaceStorageKey = "dimension:last-workspace"
-const generatedPathSegments = new Set([".git", ".vite", "coverage", "dist", "node_modules"])
 const defaultPageTitle = "Dimension Project Intelligence"
 const urlExample = readExampleFromUrl()
 const storedWorkspace = readPersistedWorkspace()
@@ -32,22 +33,6 @@ interface PersistedWorkspace {
   message: string
   exampleId?: string
   sourceUrl?: string
-}
-
-interface LocalDirectoryHandle {
-  kind: "directory"
-  name: string
-  values(): AsyncIterable<LocalDirectoryHandle | LocalFileHandle>
-}
-
-interface LocalFileHandle {
-  kind: "file"
-  name: string
-  getFile(): Promise<File>
-}
-
-type WindowWithDirectoryPicker = Window & {
-  showDirectoryPicker?: () => Promise<LocalDirectoryHandle>
 }
 
 const sourceGraph = ref<SourceGraph | undefined>(persistedWorkspace?.graph)
@@ -127,54 +112,17 @@ async function importSourceFile(event: Event): Promise<void> {
   }
 }
 
-async function openLocalProject(): Promise<void> {
-  importStatus.value = "loading"
-  importMessage.value = "Choose a local folder. Dimension will skip generated folders and parse supported code files."
+function prepareProjectFolderInput(): void {
+  const input = projectFolderInput.value
 
-  const pickerWindow = window as WindowWithDirectoryPicker
+  if (!input || isImporting.value) return
 
-  if (!pickerWindow.showDirectoryPicker) {
-    const input = projectFolderInput.value
-
-    if (!input) return
-
-    input.value = ""
-    input.addEventListener("cancel", resetLocalProjectSelection, { once: true })
-    input.click()
-    return
-  }
-
-  try {
-    const directory = await pickerWindow.showDirectoryPicker()
-
-    importMessage.value = `Listing top-level files and folders in ${directory.name}…`
-    await nextFrame()
-
-    const previewGraph = await createTopLevelProjectGraphFromDirectory(directory)
-    showLocalProjectPreview(directory.name, previewGraph)
-
-    importMessage.value = `Data-mining ${directory.name}; generated folders are skipped before supported code files are parsed…`
-    await nextFrame()
-
-    const projectFiles = await projectFilesFromDirectory(directory)
-    await importProjectFiles(directory.name, projectFiles)
-  } catch (error) {
-    if (error instanceof DOMException && error.name === "AbortError") {
-      importStatus.value = "idle"
-      importMessage.value = defaultImportMessage
-      return
-    }
-
-    importStatus.value = "error"
-    importMessage.value = error instanceof Error ? error.message : "Dimension could not open that local folder."
-  }
+  input.value = ""
 }
 
 async function importProjectFolder(event: Event): Promise<void> {
   const input = event.target as HTMLInputElement
   const files = input.files
-
-  input.removeEventListener("cancel", resetLocalProjectSelection)
 
   if (!files?.length) {
     resetLocalProjectSelection()
@@ -185,7 +133,7 @@ async function importProjectFolder(event: Event): Promise<void> {
     const rootName = projectNameForFiles(files)
     const projectFiles = projectFilesFromInput(files)
 
-    showLocalProjectPreview(rootName, createTopLevelProjectGraphFromFiles(rootName, projectFiles))
+    showLocalProjectPreview(rootName, createProjectPreviewGraphFromFiles(rootName, projectFiles))
     importMessage.value = `Data-mining ${rootName}; generated folders are skipped before supported code files are parsed…`
     await nextFrame()
 
@@ -245,87 +193,6 @@ function showLocalProjectPreview(rootName: string, graph: SourceGraph): void {
   syncDocumentTitle(rootName)
   importStatus.value = "loading"
   importMessage.value = message
-}
-
-async function createTopLevelProjectGraphFromDirectory(directory: LocalDirectoryHandle): Promise<SourceGraph> {
-  const rootName = directory.name.trim() || "Selected project"
-  const graph = createProjectRootGraph(rootName)
-
-  for await (const entry of directory.values()) {
-    addTopLevelProjectNode(graph, rootName, entry.name, entry.kind === "directory" ? "folder" : "file")
-  }
-
-  return graph
-}
-
-function createTopLevelProjectGraphFromFiles(rootName: string, projectFiles: LocalProjectFile[]): SourceGraph {
-  const graph = createProjectRootGraph(rootName)
-  const topLevelPaths = new Map<string, "file" | "folder">()
-
-  projectFiles.forEach((projectFile) => {
-    const [firstSegment, secondSegment] = projectFile.path.split("/").filter(Boolean)
-
-    if (!firstSegment) return
-
-    topLevelPaths.set(firstSegment, secondSegment ? "folder" : "file")
-  })
-
-  topLevelPaths.forEach((type, name) => addTopLevelProjectNode(graph, rootName, name, type))
-
-  return graph
-}
-
-function createProjectRootGraph(rootName: string): SourceGraph {
-  const safeRootName = rootName.trim() || "Selected project"
-
-  return {
-    nodes: [{ id: `folder:${safeRootName}`, label: safeRootName, type: "folder" }],
-    links: [],
-  }
-}
-
-function addTopLevelProjectNode(graph: SourceGraph, rootName: string, name: string, type: "file" | "folder"): void {
-  const id = `${type}:${rootName}/${name}`
-
-  graph.nodes.push({ id, label: name, type })
-  graph.links.push({ source: graph.nodes[0].id, target: id })
-}
-
-async function projectFilesFromDirectory(directory: LocalDirectoryHandle, prefix = ""): Promise<LocalProjectFile[]> {
-  const projectFiles: LocalProjectFile[] = []
-
-  for await (const entry of directory.values()) {
-    if (entry.kind === "directory" && generatedPathSegments.has(entry.name)) continue
-
-    const path = prefix ? `${prefix}/${entry.name}` : entry.name
-
-    if (entry.kind === "file") {
-      projectFiles.push({ file: await entry.getFile(), path })
-    } else {
-      projectFiles.push(...(await projectFilesFromDirectory(entry, path)))
-    }
-  }
-
-  return projectFiles
-}
-
-function projectFilesFromInput(files: FileList): LocalProjectFile[] {
-  return Array.from(files).map((file) => {
-    const relativePath = file.webkitRelativePath || file.name
-    const parts = relativePath.split("/").filter(Boolean)
-
-    return {
-      file,
-      path: parts.slice(1).join("/") || parts[0] || file.name,
-    }
-  })
-}
-
-function projectNameForFiles(files: FileList): string {
-  const relativePath = files[0]?.webkitRelativePath
-  const rootName = relativePath?.split("/").filter(Boolean)[0]
-
-  return rootName || "Selected project"
 }
 
 function selectNode(id: string): void {
@@ -477,18 +344,21 @@ function syncDocumentTitle(workspaceTitle: string): void {
             @change="importSourceFile"
           />
         </label>
-        <div class="source-import__field">
+        <label class="source-import__field" :class="{ 'source-import__field--disabled': isImporting }">
           <span>Open another project</span>
-          <button type="button" :disabled="isImporting" @click="openLocalProject">Open local folder</button>
+          <span class="source-import__button">Open local folder</span>
           <input
             ref="projectFolderInput"
             class="source-import__hidden-input"
             type="file"
             webkitdirectory
             multiple
+            :disabled="isImporting"
+            @click="prepareProjectFolderInput"
+            @cancel="resetLocalProjectSelection"
             @change="importProjectFolder"
           />
-        </div>
+        </label>
         <button type="button" :disabled="isImporting" @click="loadBuiltInSample">Load built-in sample</button>
         <div class="source-import__examples" aria-label="Public project examples">
           <span>Public examples</span>


### PR DESCRIPTION
Fixes https://github.com/klondikemarlen/dimension/issues/63

## Context

Opening a local folder still felt broken during manual QA because the hidden directory input depended on a programmatic picker path and the app only showed the completed parser graph after upload. Single-file import also used a separate graph endpoint/model, so selecting a file and selecting a folder behaved differently.

## Implementation

- Makes the folder control a label-backed native directory input, preserving keyboard focus and disabled/loading styling.
- Moves project file normalization, generated-path filtering, top-level preview graph building, and import planning into `project-folder-service`.
- Shows an immediate top-level graph preview for selected local folders before the parser upload finishes.
- Routes single-source-file import through the same project graph pipeline as folder import.
- Removes the obsolete standalone `/graphs` upload endpoint after single-file import stopped using it.
- Adds focused regression coverage for folder preview planning and exposes `npm run test:folder`.

## Testing

1. `npm run test:folder` in `web/`.
2. `npm run type-check` in `web/`.
3. `npm run build` in `web/` with `VITE_SERVER_APPLICATION_ORIGIN=http://127.0.0.1:38791`.
4. `npm run build` in `api/`.
5. `npm run test:parser` in `api/`.
6. Browser QA at `http://127.0.0.1:36925/`:
   - Source-file selection via synthetic browser `DataTransfer` reached `Mapped 1 first-layer item from app.ts`; title became `app.ts · Dimension`; no horizontal overflow.
   - Folder control click opened a native multi-select directory/file chooser from the visible `Open local folder` control.
   - Folder/project flow via synthetic files cleared stale `?example=...` URL state and mapped first-layer project nodes.

## Notes

Chromium/Puppeteer `uploadFile()` against a filesystem-backed file intermittently failed before the request reached Express with `net::ERR_ALPN_NEGOTIATION_FAILED`. The product-level QA used browser-native `File` objects via `DataTransfer`; the Vite same-origin proxy was left unchanged.
