### PR TITLE
Fix local folder import feedback

### DIFF
--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -105,12 +105,15 @@ async function importSourceFile(event: Event): Promise<void> {
   }
 }
 
-function prepareProjectFolderInput(): void {
+function openProjectFolderPicker(): void {
   const input = projectFolderInput.value
 
   if (!input || isImporting.value) return
 
   input.value = ""
+  importStatus.value = "loading"
+  importMessage.value = "Choose a folder, then select Upload in your browser dialog. The browser calls this an upload because Dimension reads its files to map the project."
+  input.click()
 }
 
 async function importProjectFolder(event: Event): Promise<void> {
@@ -336,21 +339,19 @@ function syncDocumentTitle(workspaceTitle: string): void {
             @change="importSourceFile"
           />
         </label>
-        <label class="source-import__field" :class="{ 'source-import__field--disabled': isImporting }">
+        <div class="source-import__field" :class="{ 'source-import__field--disabled': isImporting }">
           <span>Open another project</span>
-          <span class="source-import__button">Open local folder</span>
+          <button type="button" :disabled="isImporting" @click="openProjectFolderPicker">Open local folder</button>
           <input
             ref="projectFolderInput"
             class="source-import__hidden-input"
             type="file"
             webkitdirectory
             multiple
-            :disabled="isImporting"
-            @click="prepareProjectFolderInput"
             @cancel="resetLocalProjectSelection"
             @change="importProjectFolder"
           />
-        </label>
+        </div>
         <button type="button" :disabled="isImporting" @click="loadBuiltInSample">Load built-in sample</button>
         <div class="source-import__examples" aria-label="Public project examples">
           <span>Public examples</span>

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -344,8 +344,7 @@ function syncDocumentTitle(workspaceTitle: string): void {
           <button type="button" :disabled="isImporting" @click="openProjectFolderPicker">Open local folder</button>
           <input
             ref="projectFolderInput"
-            aria-hidden="true"
-            tabindex="-1"
+            hidden
             class="source-import__hidden-input"
             type="file"
             webkitdirectory

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -344,6 +344,8 @@ function syncDocumentTitle(workspaceTitle: string): void {
           <button type="button" :disabled="isImporting" @click="openProjectFolderPicker">Open local folder</button>
           <input
             ref="projectFolderInput"
+            aria-hidden="true"
+            tabindex="-1"
             class="source-import__hidden-input"
             type="file"
             webkitdirectory


### PR DESCRIPTION
Closes #65

## Summary

- trigger the folder chooser from an explicit button so Dimension can immediately enter its loading state
- explain the browser's standard **Upload** terminology before folder selection
- restore the idle guidance when the folder chooser is canceled

## Acceptance criteria

- [x] Opening the folder chooser immediately shows loading feedback and the next action
- [x] The in-app message explains why the browser calls local-folder access an upload
- [x] Cancel restores the idle guidance
- [x] A confirmed local-folder selection reaches the project preview/import flow

## Verification

- `./bin/dev run --rm web npm run build` — PASS: Vue type-check and production build completed.
- Browser QA — PASS: clicking **Open local folder** immediately rendered `Choose a folder, then select Upload…`; canceling the native chooser restored idle guidance; a browser-native `File` assigned to the directory input completed the import with `Mapped 1 first-layer item from sample-project` and three graph nodes.
- Accessibility — PASS: the native directory input is hidden from the accessibility tree; the named **Open local folder** button remains the sole control.
- Backend check — PASS: `./bin/dev ps` shows `dimension-api-1` running. The bounded API log tail contained historical shutdown `SIGTERM` records and Vite startup messages only—no request-time exception or 5xx—and the browser import completed through `/graphs/project`.

## Learner coverage

User-reported QA regression captured in #65; no separate learner issue needed.

## Self-review

PASS — reviewed the complete one-file PR change and the remote branch source after the final accessibility fix. No correctness, accessibility, or scope findings remain. Residual constraint: the browser-owned security-dialog wording cannot be customized; the app now explains it before the dialog opens.