### PR TITLE
Use native local folder picker

### DIFF
--- a/web/src/services/__tests__/project-folder-service.spec.ts
+++ b/web/src/services/__tests__/project-folder-service.spec.ts
@@ -4,6 +4,7 @@ import {
   createProjectPreviewGraphFromFiles,
   planProjectImport,
   projectFilesFromInput,
+  projectFilesFromDirectory,
   projectNameForFiles,
   type LocalProjectFile,
 } from "../project-folder-service.ts"
@@ -61,6 +62,36 @@ assert.deepEqual(
 )
 assert.equal(importPlan.skippedCount, 1)
 assert.equal(importPlan.parseableCount, 1)
+
+const selectedDirectory = {
+  name: "dimension-directory-picker-qa",
+  kind: "directory" as const,
+  async *entries() {
+    yield [
+      "src",
+      {
+        name: "src",
+        kind: "directory" as const,
+        async *entries() {
+          yield ["app.ts", { kind: "file" as const, getFile: async () => projectFile("app.ts") }]
+        },
+      },
+    ] as const
+    yield [
+      "node_modules",
+      {
+        name: "node_modules",
+        kind: "directory" as const,
+        async *entries() {
+          throw new Error("Generated directories must not be traversed.")
+        },
+      },
+    ] as const
+  },
+}
+
+const directoryFiles = await projectFilesFromDirectory(selectedDirectory)
+assert.deepEqual(directoryFiles.map((file) => file.path), ["src/app.ts"])
 
 const singleSourceGraph = createProjectPreviewGraphFromFiles("Selected source", [
   { file: projectFile("app.ts"), path: "app.ts" },

--- a/web/src/services/project-folder-service.ts
+++ b/web/src/services/project-folder-service.ts
@@ -5,6 +5,16 @@ export interface LocalProjectFile {
   path: string
 }
 
+export type ProjectDirectoryEntry =
+  | { kind: "file"; getFile(): Promise<File> }
+  | ProjectDirectoryHandle
+
+export interface ProjectDirectoryHandle {
+  name: string
+  kind: "directory"
+  entries(): AsyncIterable<[string, ProjectDirectoryEntry]>
+}
+
 export interface ProjectPreviewEntry {
   name: string
   type: "file" | "folder"
@@ -55,6 +65,32 @@ export function projectFilesFromInput(files: FileList): LocalProjectFile[] {
       path: parts.slice(1).join("/") || parts[0] || file.name,
     }
   })
+}
+
+export async function projectFilesFromDirectory(directory: ProjectDirectoryHandle): Promise<LocalProjectFile[]> {
+  const projectFiles: LocalProjectFile[] = []
+
+  async function visit(currentDirectory: ProjectDirectoryHandle, parentPath: string): Promise<void> {
+    for await (const [name, entry] of currentDirectory.entries()) {
+      const path = parentPath ? `${parentPath}/${name}` : name
+
+      if (isGeneratedPath(path)) continue
+
+      if (entry.kind === "file") {
+        projectFiles.push({ file: await entry.getFile(), path })
+
+        if (projectFiles.length > MAX_PROJECT_PATHS) {
+          throw new Error(`Dimension can map up to ${MAX_PROJECT_PATHS} project paths at once; more were selected.`)
+        }
+      } else {
+        await visit(entry, path)
+      }
+    }
+  }
+
+  await visit(directory, "")
+
+  return projectFiles
 }
 
 export function projectNameForFiles(files: FileList): string {

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -8,8 +8,10 @@ import { createGraphFromProjectFiles } from "@/services/graph-import-service"
 import {
   createProjectPreviewGraphFromFiles,
   planProjectImport,
+  projectFilesFromDirectory,
   projectFilesFromInput,
   projectNameForFiles,
+  type ProjectDirectoryHandle,
   type LocalProjectFile,
 } from "@/services/project-folder-service"
 import { createSpellDiagramFromSourceGraph } from "@/services/spell-diagram-adapter"
@@ -105,10 +107,34 @@ async function importSourceFile(event: Event): Promise<void> {
   }
 }
 
-function openProjectFolderPicker(): void {
+async function openProjectFolderPicker(): Promise<void> {
+  if (isImporting.value) return
+
+  const directoryPicker = (window as Window & { showDirectoryPicker?: () => Promise<ProjectDirectoryHandle> }).showDirectoryPicker
+
+  if (directoryPicker) {
+    importStatus.value = "loading"
+    importMessage.value = "Choose a local folder in your browser dialog to map the project."
+
+    try {
+      const directory = await directoryPicker.call(window)
+      await importLocalProject(directory.name, await projectFilesFromDirectory(directory))
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        resetLocalProjectSelection()
+        return
+      }
+
+      importStatus.value = "error"
+      importMessage.value = error instanceof Error ? error.message : "Dimension could not open that local folder."
+    }
+
+    return
+  }
+
   const input = projectFolderInput.value
 
-  if (!input || isImporting.value) return
+  if (!input) return
 
   input.value = ""
   importStatus.value = "loading"
@@ -126,18 +152,20 @@ async function importProjectFolder(event: Event): Promise<void> {
   }
 
   try {
-    const rootName = projectNameForFiles(files)
-    const projectFiles = projectFilesFromInput(files)
-
-    showLocalProjectPreview(rootName, createProjectPreviewGraphFromFiles(rootName, projectFiles))
-    importMessage.value = `Data-mining ${rootName}; generated folders are skipped before supported code files are parsed…`
-    await nextFrame()
-
-    await importProjectFiles(rootName, projectFiles)
+    await importLocalProject(projectNameForFiles(files), projectFilesFromInput(files))
   } finally {
     input.value = ""
   }
 }
+
+async function importLocalProject(rootName: string, projectFiles: LocalProjectFile[]): Promise<void> {
+  showLocalProjectPreview(rootName, createProjectPreviewGraphFromFiles(rootName, projectFiles))
+  importMessage.value = `Data-mining ${rootName}; generated folders are skipped before supported code files are parsed…`
+  await nextFrame()
+
+  await importProjectFiles(rootName, projectFiles)
+}
+
 
 function resetLocalProjectSelection(): void {
   importStatus.value = "idle"

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -166,7 +166,6 @@ async function importLocalProject(rootName: string, projectFiles: LocalProjectFi
   await importProjectFiles(rootName, projectFiles)
 }
 
-
 function resetLocalProjectSelection(): void {
   importStatus.value = "idle"
   importMessage.value = defaultImportMessage


### PR DESCRIPTION
Reopens and closes #65.

## Problem

Chrome's `webkitdirectory` flow can return an empty/canceled selection after its browser-owned **Upload** confirmation, resetting Dimension to idle before the backend receives a request.

## Fix

- Use Chrome's native `showDirectoryPicker()` when available, removing the upload confirmation from the primary path.
- Keep the existing file-input picker as a browser fallback.
- Recursively collect selected files, skip generated directories before reading files, and apply the project-path limit during collection.

## Verification

- `./bin/dev run --rm web npm run build` — PASS.
- `./bin/dev run --rm web npm run test:folder` — PASS; covers nested directory traversal and verifies `node_modules` is not traversed.
- Browser QA — PASS: mocked the supported native picker, verified it retained `window` as receiver, skipped a throwing generated-directory handle, POSTed `/graphs/project` with HTTP 200, and rendered `Mapped 1 first-layer item from native-project`.
- Native-button check — PASS: the real `showDirectoryPicker()` method exists in the local secure context and the button invoked it. The QA harness intercepts native file chooser dialogs and rejects with `AbortError: Intercepted by Page.setInterceptFileChooserDialog`, so the OS picker itself cannot be completed through this harness.

## Self-review

PASS — reviewed the complete three-file PR after the final cleanup. No correctness, scope, type, accessibility, or test findings remain. The path-cap error is deliberately surfaced through the existing import status.