### PR TITLE
Show local folder import progress

### DIFF
--- a/web/src/services/__tests__/project-folder-service.spec.ts
+++ b/web/src/services/__tests__/project-folder-service.spec.ts
@@ -90,7 +90,9 @@ const selectedDirectory = {
   },
 }
 
-const directoryFiles = await projectFilesFromDirectory(selectedDirectory)
+const directoryProgress: number[] = []
+const directoryFiles = await projectFilesFromDirectory(selectedDirectory, (fileCount) => directoryProgress.push(fileCount))
+assert.deepEqual(directoryProgress, [1])
 assert.deepEqual(directoryFiles.map((file) => file.path), ["src/app.ts"])
 
 const singleSourceGraph = createProjectPreviewGraphFromFiles("Selected source", [

--- a/web/src/services/project-folder-service.ts
+++ b/web/src/services/project-folder-service.ts
@@ -67,7 +67,10 @@ export function projectFilesFromInput(files: FileList): LocalProjectFile[] {
   })
 }
 
-export async function projectFilesFromDirectory(directory: ProjectDirectoryHandle): Promise<LocalProjectFile[]> {
+export async function projectFilesFromDirectory(
+  directory: ProjectDirectoryHandle,
+  onProgress?: (fileCount: number) => void | Promise<void>,
+): Promise<LocalProjectFile[]> {
   const projectFiles: LocalProjectFile[] = []
 
   async function visit(currentDirectory: ProjectDirectoryHandle, parentPath: string): Promise<void> {
@@ -78,6 +81,7 @@ export async function projectFilesFromDirectory(directory: ProjectDirectoryHandl
 
       if (entry.kind === "file") {
         projectFiles.push({ file: await entry.getFile(), path })
+        await onProgress?.(projectFiles.length)
 
         if (projectFiles.length > MAX_PROJECT_PATHS) {
           throw new Error(`Dimension can map up to ${MAX_PROJECT_PATHS} project paths at once; more were selected.`)

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -118,10 +118,21 @@ async function openProjectFolderPicker(): Promise<void> {
 
     try {
       const directory = await directoryPicker.call(window)
-      await importLocalProject(directory.name, await projectFilesFromDirectory(directory))
+      importMessage.value = `Reading ${directory.name}; scanning selected files…`
+      await nextFrame()
+      const projectFiles = await projectFilesFromDirectory(directory, async (fileCount) => {
+        if (fileCount !== 1 && fileCount % 100 !== 0) return
+
+        importMessage.value = `Reading ${directory.name}; found ${fileCount} file${fileCount === 1 ? "" : "s"}…`
+        await nextFrame()
+      })
+
+      if (!projectFiles.length) throw new Error(`Dimension found no files in ${directory.name}.`)
+
+      await importLocalProject(directory.name, projectFiles)
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") {
-        resetLocalProjectSelection()
+        reportFolderSelectionCanceled()
         return
       }
 
@@ -147,12 +158,17 @@ async function importProjectFolder(event: Event): Promise<void> {
   const files = input.files
 
   if (!files?.length) {
-    resetLocalProjectSelection()
+    reportFolderSelectionCanceled()
     return
   }
 
   try {
-    await importLocalProject(projectNameForFiles(files), projectFilesFromInput(files))
+    const rootName = projectNameForFiles(files)
+    importStatus.value = "loading"
+    importMessage.value = `Reading ${rootName}; ${files.length} file${files.length === 1 ? "" : "s"} attached by your browser…`
+    await nextFrame()
+
+    await importLocalProject(rootName, projectFilesFromInput(files))
   } finally {
     input.value = ""
   }
@@ -166,9 +182,11 @@ async function importLocalProject(rootName: string, projectFiles: LocalProjectFi
   await importProjectFiles(rootName, projectFiles)
 }
 
-function resetLocalProjectSelection(): void {
-  importStatus.value = "idle"
-  importMessage.value = defaultImportMessage
+function reportFolderSelectionCanceled(): void {
+  if (projectFolderInput.value?.files?.length) return
+
+  importStatus.value = "error"
+  importMessage.value = "Folder selection was canceled. No files were attached."
 }
 
 async function importProjectFiles(rootName: string, projectFiles: LocalProjectFile[], sourceName = rootName): Promise<void> {
@@ -183,7 +201,7 @@ async function importProjectFiles(rootName: string, projectFiles: LocalProjectFi
 
     const graph = await createGraphFromProjectFiles(rootName, plan.files)
     const selectedId = graph.nodes[0]?.id
-    const message = `Mapped ${directChildCount(graph, selectedId)} first-layer item${directChildCount(graph, selectedId) === 1 ? "" : "s"} from ${sourceName}; folder/file nodes are kept and supported code files were parsed.`
+    const message = `Mapped ${directChildCount(graph, selectedId)} first-layer item${directChildCount(graph, selectedId) === 1 ? "" : "s"} from ${sourceName}; ${plan.files.length} local path${plan.files.length === 1 ? "" : "s"} attached, with folder/file nodes kept and supported code files parsed.`
 
     setWorkspace({
       graph,
@@ -376,7 +394,7 @@ function syncDocumentTitle(workspaceTitle: string): void {
             type="file"
             webkitdirectory
             multiple
-            @cancel="resetLocalProjectSelection"
+            @cancel="reportFolderSelectionCanceled"
             @change="importProjectFolder"
           />
         </div>


### PR DESCRIPTION
Reopens and closes #65.

## Problem

After folder attachment, Dimension could spend time scanning paths without a distinct visible state; a canceled or empty selection reset to the generic idle message.

## Fix

- show an explicit reading state after a native folder is attached, including periodic file counts
- show the browser-attached file count before legacy picker import work starts
- retain the selected-path count in the successful import message
- report canceled or empty selections clearly instead of silently returning to idle

## Verification

- `./bin/dev run --rm web npm run test:folder` — PASS, including traversal progress.
- `./bin/dev run --rm web npm run build` — PASS.
- Real filesystem folder through the browser fallback: visible chooser instruction → `Data-mining fixtures; scanning 2 local paths…` → `/graphs/project` HTTP 200 → `Mapped 2 first-layer items from fixtures; 2 local paths attached…`.
- Native picker browser QA: visible `Reading feedback-project; scanning selected files…` before traversal; completed import returned HTTP 200 and preserved the attachment count.

## Self-review

PASS — reviewed the complete three-file PR. No correctness, type, test, accessibility, or scope findings remain. The real native OS dialog is intercepted by the QA harness; its supported primary-path call and all subsequent states are separately covered.