### PR TITLE
Isolate folder selection adapters

### DIFF
--- a/web/src/services/__tests__/project-folder-service.spec.ts
+++ b/web/src/services/__tests__/project-folder-service.spec.ts
@@ -8,6 +8,7 @@ import {
   projectNameForFiles,
   type LocalProjectFile,
 } from "../project-folder-service.ts"
+import { selectNativeDirectory, selectionFromFolderInput } from "../project-folder-selection-service.ts"
 
 function projectFile(path: string, size = 1): File {
   const parts = path.split("/")
@@ -94,6 +95,17 @@ const directoryProgress: number[] = []
 const directoryFiles = await projectFilesFromDirectory(selectedDirectory, (fileCount) => directoryProgress.push(fileCount))
 assert.deepEqual(directoryProgress, [1])
 assert.deepEqual(directoryFiles.map((file) => file.path), ["src/app.ts"])
+
+const nativeSelection = await selectNativeDirectory(async () => selectedDirectory)
+assert.equal(nativeSelection.kind, "selected")
+if (nativeSelection.kind === "selected") {
+  assert.equal(nativeSelection.rootName, "dimension-directory-picker-qa")
+  assert.deepEqual(nativeSelection.files.map((file) => file.path), ["src/app.ts"])
+}
+assert.deepEqual(await selectNativeDirectory(async () => Promise.reject(new DOMException("Canceled", "AbortError"))), {
+  kind: "canceled",
+})
+assert.deepEqual(selectionFromFolderInput(null), { kind: "canceled" })
 
 const singleSourceGraph = createProjectPreviewGraphFromFiles("Selected source", [
   { file: projectFile("app.ts"), path: "app.ts" },

--- a/web/src/services/project-folder-selection-service.ts
+++ b/web/src/services/project-folder-selection-service.ts
@@ -1,0 +1,56 @@
+import {
+  projectFilesFromDirectory,
+  projectFilesFromInput,
+  projectNameForFiles,
+  type LocalProjectFile,
+  type ProjectDirectoryHandle,
+} from "./project-folder-service.ts"
+
+export type FolderSelection =
+  | { kind: "selected"; rootName: string; files: LocalProjectFile[] }
+  | { kind: "canceled" }
+  | { kind: "unsupported" }
+  | { kind: "failed"; message: string }
+type NativeDirectoryPicker = () => Promise<ProjectDirectoryHandle>
+type SelectionProgress = (rootName: string, fileCount: number) => void | Promise<void>
+
+export function nativeDirectoryPicker(browserWindow: Window): NativeDirectoryPicker | undefined {
+  const picker = (browserWindow as Window & { showDirectoryPicker?: NativeDirectoryPicker }).showDirectoryPicker
+
+  return picker ? () => picker.call(browserWindow) : undefined
+}
+
+export async function selectNativeDirectory(
+  picker: NativeDirectoryPicker,
+  onProgress?: SelectionProgress,
+): Promise<FolderSelection> {
+  try {
+    const directory = await picker()
+    await onProgress?.(directory.name, 0)
+    const files = await projectFilesFromDirectory(directory, (fileCount) => onProgress?.(directory.name, fileCount))
+
+    return { kind: "selected", rootName: directory.name, files }
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") return { kind: "canceled" }
+
+    return {
+      kind: "failed",
+      message: error instanceof Error ? error.message : "Dimension could not open that local folder.",
+    }
+  }
+}
+
+export function selectionFromFolderInput(files: FileList | null): FolderSelection {
+  if (!files?.length) return { kind: "canceled" }
+
+  return {
+    kind: "selected",
+    rootName: projectNameForFiles(files),
+    files: projectFilesFromInput(files),
+  }
+}
+
+export function openFolderInput(input: HTMLInputElement): void {
+  input.value = ""
+  input.click()
+}

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -120,6 +120,7 @@ async function openProjectFolderPicker(): Promise<void> {
     importMessage.value = "Choose a local folder in your browser dialog to map the project."
     await importFolderSelection(
       await selectNativeDirectory(picker, async (rootName, fileCount) => {
+        if (fileCount !== 0 && fileCount !== 1 && fileCount % 100 !== 0) return
         importMessage.value = fileCount
           ? `Reading ${rootName}; found ${fileCount} file${fileCount === 1 ? "" : "s"}…`
           : `Reading ${rootName}; scanning selected files…`

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -6,12 +6,15 @@ import { usersControllerIndexDiagram } from "@/fixtures/usersControllerIndex"
 import { publicProjectExamples, type PublicProjectExample } from "@/fixtures/publicProjectExamples"
 import { createGraphFromProjectFiles } from "@/services/graph-import-service"
 import {
+  nativeDirectoryPicker,
+  openFolderInput,
+  selectNativeDirectory,
+  selectionFromFolderInput,
+  type FolderSelection,
+} from "@/services/project-folder-selection-service"
+import {
   createProjectPreviewGraphFromFiles,
   planProjectImport,
-  projectFilesFromDirectory,
-  projectFilesFromInput,
-  projectNameForFiles,
-  type ProjectDirectoryHandle,
   type LocalProjectFile,
 } from "@/services/project-folder-service"
 import { createSpellDiagramFromSourceGraph } from "@/services/spell-diagram-adapter"
@@ -110,68 +113,81 @@ async function importSourceFile(event: Event): Promise<void> {
 async function openProjectFolderPicker(): Promise<void> {
   if (isImporting.value) return
 
-  const directoryPicker = (window as Window & { showDirectoryPicker?: () => Promise<ProjectDirectoryHandle> }).showDirectoryPicker
+  const picker = nativeDirectoryPicker(window)
 
-  if (directoryPicker) {
+  if (picker) {
     importStatus.value = "loading"
     importMessage.value = "Choose a local folder in your browser dialog to map the project."
-
-    try {
-      const directory = await directoryPicker.call(window)
-      importMessage.value = `Reading ${directory.name}; scanning selected files…`
-      await nextFrame()
-      const projectFiles = await projectFilesFromDirectory(directory, async (fileCount) => {
-        if (fileCount !== 1 && fileCount % 100 !== 0) return
-
-        importMessage.value = `Reading ${directory.name}; found ${fileCount} file${fileCount === 1 ? "" : "s"}…`
+    await importFolderSelection(
+      await selectNativeDirectory(picker, async (rootName, fileCount) => {
+        importMessage.value = fileCount
+          ? `Reading ${rootName}; found ${fileCount} file${fileCount === 1 ? "" : "s"}…`
+          : `Reading ${rootName}; scanning selected files…`
         await nextFrame()
-      })
-
-      if (!projectFiles.length) throw new Error(`Dimension found no files in ${directory.name}.`)
-
-      await importLocalProject(directory.name, projectFiles)
-    } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
-        reportFolderSelectionCanceled()
-        return
-      }
-
-      importStatus.value = "error"
-      importMessage.value = error instanceof Error ? error.message : "Dimension could not open that local folder."
-    }
-
+      }),
+    )
     return
   }
 
+  openBrowserFolderPicker()
+}
+
+function openBrowserFolderPicker(): void {
+  const input = projectFolderInput.value
+
+  if (!input) {
+    void importFolderSelection({ kind: "unsupported" })
+    return
+  }
+
+  importStatus.value = "loading"
+  importMessage.value = "Choose a folder, then select Upload in your browser dialog. The browser calls this an upload because Dimension reads its files to map the project."
+  openFolderInput(input)
+}
+
+async function handleProjectFolderInput(): Promise<void> {
   const input = projectFolderInput.value
 
   if (!input) return
 
+  const selection = selectionFromFolderInput(input.files)
   input.value = ""
-  importStatus.value = "loading"
-  importMessage.value = "Choose a folder, then select Upload in your browser dialog. The browser calls this an upload because Dimension reads its files to map the project."
-  input.click()
+  await importFolderSelection(selection)
 }
 
-async function importProjectFolder(event: Event): Promise<void> {
-  const input = event.target as HTMLInputElement
-  const files = input.files
+function handleProjectFolderInputCancel(): void {
+  void importFolderSelection({ kind: "canceled" })
+}
 
-  if (!files?.length) {
+async function importFolderSelection(selection: FolderSelection): Promise<void> {
+  if (selection.kind === "canceled") {
     reportFolderSelectionCanceled()
     return
   }
 
-  try {
-    const rootName = projectNameForFiles(files)
-    importStatus.value = "loading"
-    importMessage.value = `Reading ${rootName}; ${files.length} file${files.length === 1 ? "" : "s"} attached by your browser…`
-    await nextFrame()
-
-    await importLocalProject(rootName, projectFilesFromInput(files))
-  } finally {
-    input.value = ""
+  if (selection.kind === "unsupported") {
+    importStatus.value = "error"
+    importMessage.value = "This browser cannot select local folders."
+    return
   }
+
+  if (selection.kind === "failed") {
+    importStatus.value = "error"
+    importMessage.value = selection.message
+    return
+  }
+
+  if (!selection.files.length) {
+    importStatus.value = "error"
+    importMessage.value = `Dimension found no files in ${selection.rootName}.`
+    return
+  }
+
+  importStatus.value = "loading"
+  importMessage.value = `Reading ${selection.rootName}; ${selection.files.length} file${selection.files.length === 1 ? "" : "s"} attached by your browser…`
+  await nextFrame()
+
+  await importLocalProject(selection.rootName, selection.files)
 }
 
 async function importLocalProject(rootName: string, projectFiles: LocalProjectFile[]): Promise<void> {
@@ -183,8 +199,6 @@ async function importLocalProject(rootName: string, projectFiles: LocalProjectFi
 }
 
 function reportFolderSelectionCanceled(): void {
-  if (projectFolderInput.value?.files?.length) return
-
   importStatus.value = "error"
   importMessage.value = "Folder selection was canceled. No files were attached."
 }
@@ -394,8 +408,8 @@ function syncDocumentTitle(workspaceTitle: string): void {
             type="file"
             webkitdirectory
             multiple
-            @cancel="reportFolderSelectionCanceled"
-            @change="importProjectFolder"
+            @cancel="handleProjectFolderInputCancel"
+            @change="handleProjectFolderInput"
           />
         </div>
         <button type="button" :disabled="isImporting" @click="loadBuiltInSample">Load built-in sample</button>


### PR DESCRIPTION
Implements #71 and advances #70.

## Summary

- add a typed folder-selection result contract: selected, canceled, unsupported, or failed
- isolate native picker invocation, native traversal, legacy input conversion, and input opening in `project-folder-selection-service`
- make `HomeView` consume selection results instead of `DOMException`, `FileList`, or input events
- retain responsive scan progress by yielding at file 0, 1, and every 100 files
- cover selected and canceled adapter results in the existing focused folder test

## Verification

- `./bin/dev run --rm web npm run test:folder` — PASS.
- `./bin/dev run --rm web npm run build` — PASS.
- Browser QA — mocked native selection and real filesystem directory-input fallback both returned HTTP 200 and replaced the workspace title.

## Self-review

PASS — reviewed the complete three-file PR after throttling progress updates. The selection adapter owns browser-specific API and event conversion; `HomeView` only transitions on its typed result. No correctness, responsiveness, accessibility, scope, or test findings remain.