### PR TITLE
Centralize local project import workflow

### DIFF
--- a/web/src/services/__tests__/project-folder-service.spec.ts
+++ b/web/src/services/__tests__/project-folder-service.spec.ts
@@ -9,6 +9,7 @@ import {
   type LocalProjectFile,
 } from "../project-folder-service.ts"
 import { selectNativeDirectory, selectionFromFolderInput } from "../project-folder-selection-service.ts"
+import { runProjectImport } from "../project-import-workflow-service.ts"
 
 function projectFile(path: string, size = 1): File {
   const parts = path.split("/")
@@ -106,6 +107,37 @@ assert.deepEqual(await selectNativeDirectory(async () => Promise.reject(new DOME
   kind: "canceled",
 })
 assert.deepEqual(selectionFromFolderInput(null), { kind: "canceled" })
+
+const workflowPhases: string[] = []
+let requestedPathCount = 0
+const workflowResult = await runProjectImport(
+  async () => ({ kind: "selected", rootName: "workflow-project", files: directoryFiles }),
+  async (phase) => workflowPhases.push(phase.kind),
+  async (_rootName, plan) => {
+    requestedPathCount = plan.files.length
+    return { nodes: [{ id: "folder:workflow-project", label: "workflow-project", type: "folder" }], links: [] }
+  },
+)
+assert.equal(workflowResult.kind, "success")
+if (workflowResult.kind === "success") {
+  assert.equal(workflowResult.plan.files.length, requestedPathCount)
+  assert.equal(workflowResult.graph.nodes[0]?.label, "workflow-project")
+}
+assert.deepEqual(workflowPhases, ["selecting", "reading", "planning", "requesting"])
+
+const canceledWorkflow = await runProjectImport(
+  async () => ({ kind: "canceled" }),
+  async () => undefined,
+  async () => ({ nodes: [], links: [] }),
+)
+assert.deepEqual(canceledWorkflow, { kind: "canceled" })
+
+const failedWorkflow = await runProjectImport(
+  async () => ({ kind: "failed", message: "Picker failed" }),
+  async () => undefined,
+  async () => ({ nodes: [], links: [] }),
+)
+assert.deepEqual(failedWorkflow, { kind: "failed", message: "Picker failed" })
 
 const singleSourceGraph = createProjectPreviewGraphFromFiles("Selected source", [
   { file: projectFile("app.ts"), path: "app.ts" },

--- a/web/src/services/graph-import-service.ts
+++ b/web/src/services/graph-import-service.ts
@@ -1,7 +1,7 @@
-import type { SourceGraph } from "@/types/source-graph"
-import type { ProjectImportPlan } from "@/services/project-folder-service"
+import type { ProjectImportPlan } from "./project-folder-service.ts"
+import type { SourceGraph } from "../types/source-graph.ts"
 
-const serverApplicationOrigin = import.meta.env.VITE_SERVER_APPLICATION_ORIGIN?.replace(/\/$/, "") ?? ""
+const serverApplicationOrigin = import.meta.env?.VITE_SERVER_APPLICATION_ORIGIN?.replace(/\/$/, "") ?? ""
 
 interface GraphImportResponse {
   graph?: SourceGraph

--- a/web/src/services/graph-import-service.ts
+++ b/web/src/services/graph-import-service.ts
@@ -1,5 +1,5 @@
 import type { SourceGraph } from "@/types/source-graph"
-import { planProjectImport, type LocalProjectFile } from "@/services/project-folder-service"
+import type { ProjectImportPlan } from "@/services/project-folder-service"
 
 const serverApplicationOrigin = import.meta.env.VITE_SERVER_APPLICATION_ORIGIN?.replace(/\/$/, "") ?? ""
 
@@ -8,8 +8,7 @@ interface GraphImportResponse {
   message?: string
 }
 
-export async function createGraphFromProjectFiles(rootName: string, projectFiles: LocalProjectFile[]): Promise<SourceGraph> {
-  const plan = planProjectImport(projectFiles)
+export async function createGraphFromProjectImport(rootName: string, plan: ProjectImportPlan): Promise<SourceGraph> {
   const paths = plan.files.map((projectFile) => projectFile.path)
   const parseableFiles = plan.parseableFiles
   const formData = new FormData()

--- a/web/src/services/project-folder-selection-service.ts
+++ b/web/src/services/project-folder-selection-service.ts
@@ -12,7 +12,7 @@ export type FolderSelection =
   | { kind: "unsupported" }
   | { kind: "failed"; message: string }
 type NativeDirectoryPicker = () => Promise<ProjectDirectoryHandle>
-type SelectionProgress = (rootName: string, fileCount: number) => void | Promise<void>
+export type FolderSelectionProgress = (rootName: string, fileCount: number) => void | Promise<void>
 
 export function nativeDirectoryPicker(browserWindow: Window): NativeDirectoryPicker | undefined {
   const picker = (browserWindow as Window & { showDirectoryPicker?: NativeDirectoryPicker }).showDirectoryPicker
@@ -22,7 +22,7 @@ export function nativeDirectoryPicker(browserWindow: Window): NativeDirectoryPic
 
 export async function selectNativeDirectory(
   picker: NativeDirectoryPicker,
-  onProgress?: SelectionProgress,
+  onProgress?: FolderSelectionProgress,
 ): Promise<FolderSelection> {
   try {
     const directory = await picker()
@@ -50,7 +50,22 @@ export function selectionFromFolderInput(files: FileList | null): FolderSelectio
   }
 }
 
-export function openFolderInput(input: HTMLInputElement): void {
-  input.value = ""
+export function selectFolderInput(input: HTMLInputElement | undefined): Promise<FolderSelection> {
+  if (!input) return Promise.resolve({ kind: "unsupported" })
+
+  const { promise, resolve } = Promise.withResolvers<FolderSelection>()
+  const settle = (selection: FolderSelection): void => {
+    input.removeEventListener("change", changed)
+    input.removeEventListener("cancel", canceled)
+    input.value = ""
+    resolve(selection)
+  }
+  const changed = (): void => settle(selectionFromFolderInput(input.files))
+  const canceled = (): void => settle({ kind: "canceled" })
+
+  input.addEventListener("change", changed)
+  input.addEventListener("cancel", canceled)
   input.click()
+
+  return promise
 }

--- a/web/src/services/project-import-workflow-service.ts
+++ b/web/src/services/project-import-workflow-service.ts
@@ -1,0 +1,67 @@
+import { createGraphFromProjectImport } from "@/services/graph-import-service"
+import type { FolderSelection, FolderSelectionProgress } from "@/services/project-folder-selection-service"
+import { planProjectImport, type ProjectImportPlan } from "@/services/project-folder-service"
+import type { SourceGraph } from "@/types/source-graph"
+
+export type ProjectImportPhase =
+  | { kind: "selecting" }
+  | { kind: "reading"; rootName: string; fileCount: number }
+  | { kind: "planning"; rootName: string; selectedPathCount: number }
+  | {
+      kind: "requesting"
+      rootName: string
+      pathCount: number
+      parseableCount: number
+      skippedCount: number
+    }
+
+type ProjectImportResult =
+  | { kind: "success"; rootName: string; graph: SourceGraph; plan: ProjectImportPlan }
+  | { kind: "canceled" }
+  | { kind: "unsupported" }
+  | { kind: "failed"; message: string }
+
+type FolderSelector = (onProgress: FolderSelectionProgress) => Promise<FolderSelection>
+type PhaseReporter = (phase: ProjectImportPhase) => void | Promise<void>
+
+export async function runProjectImport(selectFolder: FolderSelector, report: PhaseReporter): Promise<ProjectImportResult> {
+  const selectionPromise = selectFolder((rootName, fileCount) => {
+    if (fileCount !== 0 && fileCount !== 1 && fileCount % 100 !== 0) return
+
+    return report({ kind: "reading", rootName, fileCount })
+  })
+  await report({ kind: "selecting" })
+
+  const selection = await selectionPromise
+
+  if (selection.kind !== "selected") return selection
+
+  if (!selection.files.length) {
+    return { kind: "failed", message: `Dimension found no files in ${selection.rootName}.` }
+  }
+
+  try {
+    await report({ kind: "reading", rootName: selection.rootName, fileCount: selection.files.length })
+    await report({ kind: "planning", rootName: selection.rootName, selectedPathCount: selection.files.length })
+    const plan = planProjectImport(selection.files)
+    await report({
+      kind: "requesting",
+      rootName: selection.rootName,
+      pathCount: plan.files.length,
+      parseableCount: plan.parseableCount,
+      skippedCount: plan.skippedCount,
+    })
+
+    return {
+      kind: "success",
+      rootName: selection.rootName,
+      plan,
+      graph: await createGraphFromProjectImport(selection.rootName, plan),
+    }
+  } catch (error) {
+    return {
+      kind: "failed",
+      message: error instanceof Error ? error.message : `Dimension could not map ${selection.rootName}.`,
+    }
+  }
+}

--- a/web/src/services/project-import-workflow-service.ts
+++ b/web/src/services/project-import-workflow-service.ts
@@ -1,7 +1,7 @@
-import { createGraphFromProjectImport } from "@/services/graph-import-service"
-import type { FolderSelection, FolderSelectionProgress } from "@/services/project-folder-selection-service"
-import { planProjectImport, type ProjectImportPlan } from "@/services/project-folder-service"
-import type { SourceGraph } from "@/types/source-graph"
+import { createGraphFromProjectImport } from "./graph-import-service.ts"
+import type { FolderSelection, FolderSelectionProgress } from "./project-folder-selection-service.ts"
+import { planProjectImport, type ProjectImportPlan } from "./project-folder-service.ts"
+import type { SourceGraph } from "../types/source-graph.ts"
 
 export type ProjectImportPhase =
   | { kind: "selecting" }
@@ -23,8 +23,13 @@ type ProjectImportResult =
 
 type FolderSelector = (onProgress: FolderSelectionProgress) => Promise<FolderSelection>
 type PhaseReporter = (phase: ProjectImportPhase) => void | Promise<void>
+type GraphCreator = (rootName: string, plan: ProjectImportPlan) => Promise<SourceGraph>
 
-export async function runProjectImport(selectFolder: FolderSelector, report: PhaseReporter): Promise<ProjectImportResult> {
+export async function runProjectImport(
+  selectFolder: FolderSelector,
+  report: PhaseReporter,
+  createGraph: GraphCreator = createGraphFromProjectImport,
+): Promise<ProjectImportResult> {
   const selectionPromise = selectFolder((rootName, fileCount) => {
     if (fileCount !== 0 && fileCount !== 1 && fileCount % 100 !== 0) return
 
@@ -56,7 +61,7 @@ export async function runProjectImport(selectFolder: FolderSelector, report: Pha
       kind: "success",
       rootName: selection.rootName,
       plan,
-      graph: await createGraphFromProjectImport(selection.rootName, plan),
+      graph: await createGraph(selection.rootName, plan),
     }
   } catch (error) {
     return {

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -4,19 +4,17 @@ import { computed, nextTick, ref } from "vue"
 import SpellCanvas from "@/components/SpellCanvas.vue"
 import { usersControllerIndexDiagram } from "@/fixtures/usersControllerIndex"
 import { publicProjectExamples, type PublicProjectExample } from "@/fixtures/publicProjectExamples"
-import { createGraphFromProjectFiles } from "@/services/graph-import-service"
 import {
   nativeDirectoryPicker,
-  openFolderInput,
+  selectFolderInput,
   selectNativeDirectory,
-  selectionFromFolderInput,
   type FolderSelection,
+  type FolderSelectionProgress,
 } from "@/services/project-folder-selection-service"
 import {
-  createProjectPreviewGraphFromFiles,
-  planProjectImport,
-  type LocalProjectFile,
-} from "@/services/project-folder-service"
+  runProjectImport,
+  type ProjectImportPhase,
+} from "@/services/project-import-workflow-service"
 import { createSpellDiagramFromSourceGraph } from "@/services/spell-diagram-adapter"
 import type { SourceGraph } from "@/types/source-graph"
 import type { RuneNode, SpellDiagram } from "@/types/spell-diagram"
@@ -92,19 +90,16 @@ async function importSourceFile(event: Event): Promise<void> {
 
   if (!sourceFile) return
 
-  const rootName = "Selected source"
-  const sourceName = sourceFile.name
-  const projectFiles: LocalProjectFile[] = [{ file: sourceFile, path: sourceFile.name }]
-
   try {
-    showLocalProjectPreview(rootName, createProjectPreviewGraphFromFiles(rootName, projectFiles), sourceName)
-    importMessage.value = `Data-mining ${sourceName}; parsing 1 supported code file…`
-    await nextFrame()
-
-    await importProjectFiles(rootName, projectFiles, sourceName)
-  } catch (error) {
-    importStatus.value = "error"
-    importMessage.value = error instanceof Error ? error.message : "Dimension could not map that source file."
+    await completeProjectImport(
+      async () => ({
+        kind: "selected",
+        rootName: "Selected source",
+        files: [{ file: sourceFile, path: sourceFile.name }],
+      }),
+      `Reading ${sourceFile.name}; preparing the selected source file…`,
+      sourceFile.name,
+    )
   } finally {
     input.value = ""
   }
@@ -114,140 +109,78 @@ async function openProjectFolderPicker(): Promise<void> {
   if (isImporting.value) return
 
   const picker = nativeDirectoryPicker(window)
+  const selectFolder = picker
+    ? (onProgress: (rootName: string, fileCount: number) => void | Promise<void>) =>
+        selectNativeDirectory(picker, onProgress)
+    : () => selectFolderInput(projectFolderInput.value)
+  const selectingMessage = picker
+    ? "Choose a local folder in your browser dialog to map the project."
+    : "Choose a folder, then select Upload in your browser dialog. The browser calls this an upload because Dimension reads its files to map the project."
 
-  if (picker) {
-    importStatus.value = "loading"
-    importMessage.value = "Choose a local folder in your browser dialog to map the project."
-    await importFolderSelection(
-      await selectNativeDirectory(picker, async (rootName, fileCount) => {
-        if (fileCount !== 0 && fileCount !== 1 && fileCount % 100 !== 0) return
-        importMessage.value = fileCount
-          ? `Reading ${rootName}; found ${fileCount} file${fileCount === 1 ? "" : "s"}…`
-          : `Reading ${rootName}; scanning selected files…`
-        await nextFrame()
-      }),
-    )
+  await completeProjectImport(selectFolder, selectingMessage)
+}
+
+async function completeProjectImport(
+  selectFolder: (onProgress: FolderSelectionProgress) => Promise<FolderSelection>,
+  selectingMessage: string,
+  sourceName?: string,
+): Promise<void> {
+  const result = await runProjectImport(selectFolder, (phase) => reportProjectImportPhase(phase, selectingMessage))
+
+  if (result.kind === "canceled") {
+    importStatus.value = "error"
+    importMessage.value = "Folder selection was canceled. No files were attached."
     return
   }
 
-  openBrowserFolderPicker()
-}
-
-function openBrowserFolderPicker(): void {
-  const input = projectFolderInput.value
-
-  if (!input) {
-    void importFolderSelection({ kind: "unsupported" })
-    return
-  }
-
-  importStatus.value = "loading"
-  importMessage.value = "Choose a folder, then select Upload in your browser dialog. The browser calls this an upload because Dimension reads its files to map the project."
-  openFolderInput(input)
-}
-
-async function handleProjectFolderInput(): Promise<void> {
-  const input = projectFolderInput.value
-
-  if (!input) return
-
-  const selection = selectionFromFolderInput(input.files)
-  input.value = ""
-  await importFolderSelection(selection)
-}
-
-function handleProjectFolderInputCancel(): void {
-  void importFolderSelection({ kind: "canceled" })
-}
-
-async function importFolderSelection(selection: FolderSelection): Promise<void> {
-  if (selection.kind === "canceled") {
-    reportFolderSelectionCanceled()
-    return
-  }
-
-  if (selection.kind === "unsupported") {
+  if (result.kind === "unsupported") {
     importStatus.value = "error"
     importMessage.value = "This browser cannot select local folders."
     return
   }
 
-  if (selection.kind === "failed") {
+  if (result.kind === "failed") {
     importStatus.value = "error"
-    importMessage.value = selection.message
+    importMessage.value = result.message
     return
   }
 
-  if (!selection.files.length) {
-    importStatus.value = "error"
-    importMessage.value = `Dimension found no files in ${selection.rootName}.`
-    return
+  const selectedId = result.graph.nodes[0]?.id
+  const title = sourceName ?? result.rootName
+  const message = `Mapped ${directChildCount(result.graph, selectedId)} first-layer item${directChildCount(result.graph, selectedId) === 1 ? "" : "s"} from ${title}; ${result.plan.files.length} local path${result.plan.files.length === 1 ? "" : "s"} attached, with folder/file nodes kept and supported code files parsed.`
+
+  setWorkspace({
+    graph: result.graph,
+    title,
+    subtitle: "Source map with file/folder hierarchy and parsed TypeScript, JavaScript, and Ruby code beneath files.",
+    sourceName: title,
+    sourceUrl: undefined,
+    selectedNodeId: selectedId,
+    message,
+  })
+}
+
+async function reportProjectImportPhase(phase: ProjectImportPhase, selectingMessage: string): Promise<void> {
+  importStatus.value = "loading"
+
+  switch (phase.kind) {
+    case "selecting":
+      importMessage.value = selectingMessage
+      break
+    case "reading":
+      importMessage.value = phase.fileCount
+        ? `Reading ${phase.rootName}; found ${phase.fileCount} file${phase.fileCount === 1 ? "" : "s"}…`
+        : `Reading ${phase.rootName}; scanning selected files…`
+      break
+    case "planning":
+      importMessage.value = `Planning ${phase.rootName}; checking ${phase.selectedPathCount} attached local path${phase.selectedPathCount === 1 ? "" : "s"}…`
+      break
+    case "requesting":
+      importMessage.value = `Data-mining ${phase.rootName}; scanning ${phase.pathCount} local path${phase.pathCount === 1 ? "" : "s"}, parsing ${phase.parseableCount} supported code file${phase.parseableCount === 1 ? "" : "s"}${phase.skippedCount ? `, and skipping ${phase.skippedCount} generated path${phase.skippedCount === 1 ? "" : "s"}` : ""}…`
+      break
   }
 
-  importStatus.value = "loading"
-  importMessage.value = `Reading ${selection.rootName}; ${selection.files.length} file${selection.files.length === 1 ? "" : "s"} attached by your browser…`
   await nextFrame()
-
-  await importLocalProject(selection.rootName, selection.files)
-}
-
-async function importLocalProject(rootName: string, projectFiles: LocalProjectFile[]): Promise<void> {
-  showLocalProjectPreview(rootName, createProjectPreviewGraphFromFiles(rootName, projectFiles))
-  importMessage.value = `Data-mining ${rootName}; generated folders are skipped before supported code files are parsed…`
-  await nextFrame()
-
-  await importProjectFiles(rootName, projectFiles)
-}
-
-function reportFolderSelectionCanceled(): void {
-  importStatus.value = "error"
-  importMessage.value = "Folder selection was canceled. No files were attached."
-}
-
-async function importProjectFiles(rootName: string, projectFiles: LocalProjectFile[], sourceName = rootName): Promise<void> {
-  try {
-    importStatus.value = "loading"
-    importMessage.value = `Preparing ${projectFiles.length} selected local path${projectFiles.length === 1 ? "" : "s"}…`
-    await nextFrame()
-
-    const plan = planProjectImport(projectFiles)
-    importMessage.value = `Data-mining ${sourceName}; scanning ${plan.files.length} local path${plan.files.length === 1 ? "" : "s"}, parsing ${plan.parseableCount} supported code file${plan.parseableCount === 1 ? "" : "s"}${plan.skippedCount ? `, and skipping ${plan.skippedCount} generated path${plan.skippedCount === 1 ? "" : "s"}` : ""}…`
-    await nextFrame()
-
-    const graph = await createGraphFromProjectFiles(rootName, plan.files)
-    const selectedId = graph.nodes[0]?.id
-    const message = `Mapped ${directChildCount(graph, selectedId)} first-layer item${directChildCount(graph, selectedId) === 1 ? "" : "s"} from ${sourceName}; ${plan.files.length} local path${plan.files.length === 1 ? "" : "s"} attached, with folder/file nodes kept and supported code files parsed.`
-
-    setWorkspace({
-      graph,
-      title: sourceName,
-      subtitle: "Source map with file/folder hierarchy and parsed TypeScript, JavaScript, and Ruby code beneath files.",
-      sourceName,
-      sourceUrl: undefined,
-      selectedNodeId: selectedId,
-      message,
-    })
-  } catch (error) {
-    importStatus.value = "error"
-    importMessage.value = error instanceof Error ? error.message : `Dimension could not map ${sourceName}.`
-  }
-}
-
-function showLocalProjectPreview(rootName: string, graph: SourceGraph, sourceName = rootName): void {
-  const selectedId = graph.nodes[0]?.id
-  const message = `Listed ${directChildCount(graph, selectedId)} top-level item${directChildCount(graph, selectedId) === 1 ? "" : "s"} from ${sourceName}; data-mining supported code files…`
-
-  sourceGraph.value = graph
-  diagramTitle.value = sourceName
-  diagramSubtitle.value = "Source map with top-level files and folders while Dimension data-mines code relationships."
-  selectedSourceName.value = sourceName
-  selectedSourceUrl.value = undefined
-  selectedNodeId.value = selectedId
-  selectedExampleId.value = undefined
-  replaceUrlState()
-  syncDocumentTitle(sourceName)
-  importStatus.value = "loading"
-  importMessage.value = message
 }
 
 function selectNode(id: string): void {
@@ -409,8 +342,6 @@ function syncDocumentTitle(workspaceTitle: string): void {
             type="file"
             webkitdirectory
             multiple
-            @cancel="handleProjectFolderInputCancel"
-            @change="handleProjectFolderInput"
           />
         </div>
         <button type="button" :disabled="isImporting" @click="loadBuiltInSample">Load built-in sample</button>

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -4,6 +4,7 @@
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
 
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
Implements #72 and advances #70.

## Summary

- add one workflow service for selecting, reading, planning, requesting, success, cancellation, and failure
- invoke selection before awaiting UI paints to preserve browser user activation
- plan selected paths exactly once; graph transport now receives that plan directly
- commit graph/title/count workspace state only after a successful server graph response
- remove preview mutation during import so the built-in workspace cannot be mistaken for an imported graph
- cover workflow phase order, cancellation/failure passthrough, and one-plan success output with an injected graph creator

## Verification

- `./bin/dev run --rm web npm run build` — PASS.
- `./bin/dev run --rm web npm run test:folder` — PASS.
- Browser file-input acceptance — selected the real `web/src/fixtures` folder, observed one `/graphs/project` HTTP 200, title `fixtures`, canvas label `fixtures`, counts 13 nodes/12 links, and success status with 2 attached paths.

## Desktop acceptance gate

Native desktop selection must be observed manually before #70 is closed. The automated harness intercepts its OS dialog, so mocks are not used as that evidence.

## Self-review

PASS — reviewed the complete five-file PR after adding workflow regression coverage and preserving synchronous picker invocation. No correctness, activation, planning, state-ownership, or scope findings remain.