### PR TITLE
Add Electron desktop workspace foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ The project uses the checked-in Docker Compose wrapper. `bin/dev up` writes rand
 ./bin/dev down
 ```
 
+Run the desktop host in a second terminal after the web service is ready:
+
+```sh
+./bin/dev desktop
+```
+
 PlantUML is behind the `design` Compose profile:
 
 ```sh

--- a/bin/dev
+++ b/bin/dev
@@ -91,6 +91,15 @@ class DevHelper
     run(*%w[web], *args, **kwargs)
   end
 
+  def desktop(*args)
+    ensure_development_ports!
+    web_origin = "http://127.0.0.1:#{development_port("DIMENSION_WEB_PORT", 58501)}"
+
+    Dir.chdir(project_root) do
+      exec({ "DIMENSION_WEB_ORIGIN" => web_origin }, "npm", "run", "desktop", "--", *args)
+    end
+  end
+
   def check_types(*args, **kwargs)
     run(*%w[api npm run check-types], *args, **kwargs)
   end

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -1,11 +1,8 @@
 const { app, BrowserWindow, ipcMain } = require("electron")
 const path = require("node:path")
 
-const rendererOrigin = process.env.DIMENSION_WEB_ORIGIN
-
-if (!rendererOrigin) {
-  throw new Error("DIMENSION_WEB_ORIGIN must point to the Dimension web renderer.")
-}
+const rendererUrl = new URL(process.env.DIMENSION_WEB_ORIGIN)
+const rendererOrigin = rendererUrl.origin
 
 async function createWindow() {
   const window = new BrowserWindow({
@@ -20,7 +17,12 @@ async function createWindow() {
     },
   })
 
-  await window.loadURL(rendererOrigin)
+  window.webContents.setWindowOpenHandler(() => ({ action: "deny" }))
+  window.webContents.on("will-navigate", (event, url) => {
+    if (new URL(url).origin !== rendererOrigin) event.preventDefault()
+  })
+
+  await window.loadURL(rendererUrl.href)
 
   if (process.env.DIMENSION_DESKTOP_SMOKE_TEST) {
     const runtime = await window.webContents.executeJavaScript("window.dimensionDesktop.runtime()")

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -1,0 +1,50 @@
+const { app, BrowserWindow, ipcMain } = require("electron")
+const path = require("node:path")
+
+const rendererOrigin = process.env.DIMENSION_WEB_ORIGIN
+
+if (!rendererOrigin) {
+  throw new Error("DIMENSION_WEB_ORIGIN must point to the Dimension web renderer.")
+}
+
+async function createWindow() {
+  const window = new BrowserWindow({
+    width: 1440,
+    height: 960,
+    minWidth: 1024,
+    minHeight: 720,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: path.join(__dirname, "preload.cjs"),
+    },
+  })
+
+  await window.loadURL(rendererOrigin)
+
+  if (process.env.DIMENSION_DESKTOP_SMOKE_TEST) {
+    const runtime = await window.webContents.executeJavaScript("window.dimensionDesktop.runtime()")
+
+    if (runtime.platform !== process.platform) throw new Error("Desktop preload bridge is unavailable.")
+    app.exit()
+  }
+}
+
+app
+  .whenReady()
+  .then(async () => {
+    ipcMain.handle("dimension:runtime", () => ({ platform: process.platform }))
+    await createWindow()
+
+    app.on("activate", () => {
+      if (!BrowserWindow.getAllWindows().length) void createWindow()
+    })
+  })
+  .catch((error) => {
+    console.error(error)
+    app.exit(1)
+  })
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit()
+})

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require("electron")
+
+contextBridge.exposeInMainWorld("dimensionDesktop", {
+  runtime: () => ipcRenderer.invoke("dimension:runtime"),
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "dimension-development-tooling",
       "devDependencies": {
+        "electron": "^43.2.0",
         "eslint": "^9.12.0",
         "eslint-config-prettier": "^9.1.0",
         "prettier": "^3.3.3",
@@ -20,6 +21,37 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
+      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -237,6 +269,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/pegjs": {
       "version": "0.10.6",
       "resolved": "https://registry.npmjs.org/@types/pegjs/-/pegjs-0.10.6.tgz",
@@ -451,6 +493,38 @@
       "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/electron": {
+      "version": "43.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.2.0.tgz",
+      "integrity": "sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js",
+        "install-electron": "install.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -761,6 +835,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -1154,6 +1235,16 @@
         "prettier": "^3.0.3"
       }
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -1203,6 +1294,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -1255,6 +1359,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1303,6 +1420,24 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "dimension-development-tooling",
   "private": true,
+  "scripts": {
+    "desktop": "electron desktop/main.cjs"
+  },
   "devDependencies": {
+    "electron": "^43.2.0",
     "eslint": "^9.12.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "^3.3.3",

--- a/web/src/types/dimension-desktop.d.ts
+++ b/web/src/types/dimension-desktop.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+  dimensionDesktop?: {
+    runtime: () => Promise<{ platform: string }>
+  }
+}


### PR DESCRIPTION
Closes #77.

## Summary
- package an Electron host for the existing Vue workspace renderer
- isolate native access behind a minimal preload IPC bridge
- add `bin/dev desktop` to launch against the running local renderer

## Verification
- `./bin/dev run --rm web npm run build`
- `DIMENSION_DESKTOP_SMOKE_TEST=1 ./bin/dev desktop --headless --disable-gpu --no-sandbox`

## Self-review
Pending complete PR-diff review after creation.