### PR TITLE
Open native project workspaces

### DIFF
--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -1,5 +1,7 @@
-const { app, BrowserWindow, ipcMain } = require("electron")
+const { app, BrowserWindow, dialog, ipcMain } = require("electron")
 const path = require("node:path")
+
+const { openWorkspace } = require("./workspace.cjs")
 
 const rendererUrl = new URL(process.env.DIMENSION_WEB_ORIGIN)
 const rendererOrigin = rendererUrl.origin
@@ -25,9 +27,13 @@ async function createWindow() {
   await window.loadURL(rendererUrl.href)
 
   if (process.env.DIMENSION_DESKTOP_SMOKE_TEST) {
-    const runtime = await window.webContents.executeJavaScript("window.dimensionDesktop.runtime()")
+    const [runtime, hasWorkspacePicker] = await window.webContents.executeJavaScript(
+      "Promise.all([window.dimensionDesktop.runtime(), typeof window.dimensionDesktop.openWorkspace === 'function'])",
+    )
 
-    if (runtime.platform !== process.platform) throw new Error("Desktop preload bridge is unavailable.")
+    if (runtime.platform !== process.platform || !hasWorkspacePicker) {
+      throw new Error("Desktop preload bridge is unavailable.")
+    }
     app.exit()
   }
 }
@@ -36,6 +42,9 @@ app
   .whenReady()
   .then(async () => {
     ipcMain.handle("dimension:runtime", () => ({ platform: process.platform }))
+    ipcMain.handle("dimension:open-workspace", () =>
+      openWorkspace({ dialog, userDataPath: app.getPath("userData") }),
+    )
     await createWindow()
 
     app.on("activate", () => {

--- a/desktop/preload.cjs
+++ b/desktop/preload.cjs
@@ -2,4 +2,5 @@ const { contextBridge, ipcRenderer } = require("electron")
 
 contextBridge.exposeInMainWorld("dimensionDesktop", {
   runtime: () => ipcRenderer.invoke("dimension:runtime"),
+  openWorkspace: () => ipcRenderer.invoke("dimension:open-workspace"),
 })

--- a/desktop/workspace.cjs
+++ b/desktop/workspace.cjs
@@ -1,0 +1,84 @@
+const { createHash } = require("node:crypto")
+const { mkdir, readFile, readdir, writeFile } = require("node:fs/promises")
+const { basename, join, relative } = require("node:path")
+
+const GENERATED_DIRECTORIES = new Set([".git", ".vite", "coverage", "dist", "node_modules"])
+const MAX_PROJECT_PATHS = 15_000
+
+async function openWorkspace({ dialog, userDataPath }) {
+  const selection = await dialog.showOpenDialog({
+    title: "Open Dimension workspace",
+    properties: ["openDirectory"],
+  })
+
+  if (selection.canceled || !selection.filePaths[0]) return { kind: "canceled" }
+
+  const rootPath = selection.filePaths[0]
+  const name = workspaceName(rootPath)
+  const graph = await createWorkspaceGraph(rootPath, name)
+  const workspace = {
+    id: createHash("sha256").update(rootPath).digest("hex"),
+    name,
+    graph,
+  }
+
+  await persistWorkspaceMetadata(userDataPath, { id: workspace.id, name, rootPath })
+
+  return { kind: "selected", workspace }
+}
+
+function workspaceName(rootPath) {
+  return basename(rootPath) || rootPath
+}
+
+async function createWorkspaceGraph(rootPath, rootName) {
+  const nodes = []
+  const links = []
+  const rootId = `folder:${rootName}`
+
+  nodes.push({ id: rootId, label: rootName, type: "folder" })
+
+  try {
+    await visitDirectory(rootPath, rootPath, rootId, rootName, nodes, links)
+  } catch (error) {
+    throw new Error(`Dimension could not read ${rootName}: ${error.message}`)
+  }
+
+  return { nodes, links }
+}
+
+async function visitDirectory(rootPath, directoryPath, parentId, rootName, nodes, links) {
+  const entries = await readdir(directoryPath, { withFileTypes: true })
+
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (entry.isDirectory() && GENERATED_DIRECTORIES.has(entry.name)) continue
+    if (nodes.length >= MAX_PROJECT_PATHS) throw new Error(`more than ${MAX_PROJECT_PATHS} paths were selected`)
+
+    const path = relative(rootPath, join(directoryPath, entry.name)).split("\\").join("/")
+    const type = entry.isDirectory() ? "folder" : "file"
+    const id = `${type}:${rootName}/${path}`
+
+    nodes.push({ id, label: entry.name, type })
+    links.push({ source: parentId, target: id })
+
+    if (entry.isDirectory()) await visitDirectory(rootPath, join(directoryPath, entry.name), id, rootName, nodes, links)
+  }
+}
+
+async function persistWorkspaceMetadata(userDataPath, workspace) {
+  const metadataPath = join(userDataPath, "workspaces.json")
+  await mkdir(userDataPath, { recursive: true })
+
+  let workspaces = []
+  try {
+    workspaces = JSON.parse(await readFile(metadataPath, "utf8"))
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error
+  }
+
+  const savedWorkspaces = workspaces.filter(({ id }) => id !== workspace.id)
+  savedWorkspaces.push(workspace)
+  await writeFile(metadataPath, JSON.stringify(savedWorkspaces, null, 2))
+}
+
+module.exports = { createWorkspaceGraph, openWorkspace, workspaceName }

--- a/desktop/workspace.test.cjs
+++ b/desktop/workspace.test.cjs
@@ -1,0 +1,51 @@
+const assert = require("node:assert/strict")
+const { mkdtemp, mkdir, readFile, writeFile } = require("node:fs/promises")
+const { tmpdir } = require("node:os")
+const { join } = require("node:path")
+const test = require("node:test")
+
+const { createWorkspaceGraph, openWorkspace, workspaceName } = require("./workspace.cjs")
+
+test("creates a native project graph and persists metadata outside the root", async () => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "dimension-workspace-"))
+  const projectRoot = join(temporaryDirectory, "project")
+  const userDataPath = join(temporaryDirectory, "dimension-data")
+  await mkdir(join(projectRoot, "src"), { recursive: true })
+  await mkdir(join(projectRoot, "node_modules"), { recursive: true })
+  await writeFile(join(projectRoot, "src", "app.ts"), "export const app = true\n")
+  await writeFile(join(projectRoot, "node_modules", "ignored.js"), "")
+
+  const result = await openWorkspace({
+    dialog: { showOpenDialog: async () => ({ canceled: false, filePaths: [projectRoot] }) },
+    userDataPath,
+  })
+
+  assert.equal(result.kind, "selected")
+  assert.equal(result.workspace.name, "project")
+  assert.deepEqual(result.workspace.graph.nodes.map(({ id }) => id), [
+    "folder:project",
+    "folder:project/src",
+    "file:project/src/app.ts",
+  ])
+  assert.match(await readFile(join(userDataPath, "workspaces.json"), "utf8"), /"rootPath"/)
+})
+
+test("reports native picker cancellation without reading a project", async () => {
+  const result = await openWorkspace({
+    dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
+    userDataPath: tmpdir(),
+  })
+
+  assert.deepEqual(result, { kind: "canceled" })
+})
+
+test("reports inaccessible native roots", async () => {
+  await assert.rejects(
+    createWorkspaceGraph(join(tmpdir(), "dimension-missing-root"), "missing-root"),
+    /Dimension could not read missing-root/,
+  )
+})
+
+test("uses the selected root when it has no basename", () => {
+  assert.equal(workspaceName("/"), "/")
+})

--- a/desktop/workspace.test.cjs
+++ b/desktop/workspace.test.cjs
@@ -1,13 +1,14 @@
 const assert = require("node:assert/strict")
-const { mkdtemp, mkdir, readFile, writeFile } = require("node:fs/promises")
+const { mkdir, mkdtemp, readFile, rm, writeFile } = require("node:fs/promises")
 const { tmpdir } = require("node:os")
 const { join } = require("node:path")
 const test = require("node:test")
 
 const { createWorkspaceGraph, openWorkspace, workspaceName } = require("./workspace.cjs")
 
-test("creates a native project graph and persists metadata outside the root", async () => {
+test("creates a native project graph and persists metadata outside the root", async (t) => {
   const temporaryDirectory = await mkdtemp(join(tmpdir(), "dimension-workspace-"))
+  t.after(() => rm(temporaryDirectory, { force: true, recursive: true }))
   const projectRoot = join(temporaryDirectory, "project")
   const userDataPath = join(temporaryDirectory, "dimension-data")
   await mkdir(join(projectRoot, "src"), { recursive: true })
@@ -39,9 +40,12 @@ test("reports native picker cancellation without reading a project", async () =>
   assert.deepEqual(result, { kind: "canceled" })
 })
 
-test("reports inaccessible native roots", async () => {
+test("reports inaccessible native roots", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "dimension-missing-root-"))
+  t.after(() => rm(temporaryDirectory, { force: true, recursive: true }))
+
   await assert.rejects(
-    createWorkspaceGraph(join(tmpdir(), "dimension-missing-root"), "missing-root"),
+    createWorkspaceGraph(join(temporaryDirectory, "missing-root"), "missing-root"),
     /Dimension could not read missing-root/,
   )
 })

--- a/web/src/types/dimension-desktop.d.ts
+++ b/web/src/types/dimension-desktop.d.ts
@@ -1,5 +1,20 @@
-interface Window {
-  dimensionDesktop?: {
-    runtime: () => Promise<{ platform: string }>
+import type { SourceGraph } from "./source-graph"
+
+declare global {
+  interface DimensionDesktopWorkspace {
+    id: string
+    name: string
+    graph: SourceGraph
+  }
+
+  type DimensionDesktopWorkspaceResult =
+    | { kind: "canceled" }
+    | { kind: "selected"; workspace: DimensionDesktopWorkspace }
+
+  interface Window {
+    dimensionDesktop?: {
+      runtime: () => Promise<{ platform: string }>
+      openWorkspace: () => Promise<DimensionDesktopWorkspaceResult>
+    }
   }
 }

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -108,6 +108,12 @@ async function importSourceFile(event: Event): Promise<void> {
 async function openProjectFolderPicker(): Promise<void> {
   if (isImporting.value) return
 
+  const desktop = window.dimensionDesktop
+  if (desktop) {
+    await openNativeWorkspace(desktop)
+    return
+  }
+
   const picker = nativeDirectoryPicker(window)
   const selectFolder = picker
     ? (onProgress: (rootName: string, fileCount: number) => void | Promise<void>) =>
@@ -118,6 +124,36 @@ async function openProjectFolderPicker(): Promise<void> {
     : "Choose a folder, then select Upload in your browser dialog. The browser calls this an upload because Dimension reads its files to map the project."
 
   await completeProjectImport(selectFolder, selectingMessage)
+}
+
+async function openNativeWorkspace(desktop: NonNullable<Window["dimensionDesktop"]>): Promise<void> {
+  importStatus.value = "loading"
+  importMessage.value = "Opening your local folder picker…"
+
+  try {
+    const result = await desktop.openWorkspace()
+    if (result.kind === "canceled") {
+      importStatus.value = "error"
+      importMessage.value = "Folder selection was canceled. No project was opened."
+      return
+    }
+
+    const { workspace } = result
+    const selectedId = workspace.graph.nodes[0]?.id
+    const firstLayerCount = directChildCount(workspace.graph, selectedId)
+    setWorkspace({
+      graph: workspace.graph,
+      title: workspace.name,
+      subtitle: "Native workspace with local folder/file hierarchy.",
+      sourceName: workspace.name,
+      sourceUrl: undefined,
+      selectedNodeId: selectedId,
+      message: `Mapped ${firstLayerCount} first-layer item${firstLayerCount === 1 ? "" : "s"} from ${workspace.name}; the local workspace root stays in the desktop host.`,
+    })
+  } catch (error) {
+    importStatus.value = "error"
+    importMessage.value = error instanceof Error ? error.message : "Dimension could not open the selected folder."
+  }
 }
 
 async function completeProjectImport(


### PR DESCRIPTION
Closes #78.

## Summary
- open a native directory dialog from Electron's main process
- map the selected folder into the existing graph workspace without browser `FileList` transfer
- persist the workspace identity and root only in Electron user data

## Verification
- `node --test desktop/workspace.test.cjs`
- `./bin/dev run --rm web npm run build`
- `DIMENSION_DESKTOP_SMOKE_TEST=1 ./bin/dev desktop --headless --disable-gpu --no-sandbox`
- Browser QA: simulated native selection renders `native-project`; cancellation reports no project opened.

## Self-review
Pending complete PR-diff review after creation.