### PR TITLE
Show Local File Import Relationships

### DIFF
--- a/desktop/workspace.cjs
+++ b/desktop/workspace.cjs
@@ -5,8 +5,6 @@ const { basename, dirname, extname, join, normalize, relative } = require("node:
 const GENERATED_DIRECTORIES = new Set([".git", ".vite", "coverage", "dist", "node_modules"])
 const IMPORTABLE_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"])
 const IMPORT_PATH_EXTENSIONS = [...IMPORTABLE_EXTENSIONS]
-const IMPORT_SPECIFIER_PATTERN =
-  /\b(?:import|export)\s+(?:[^'"]*?\s+from\s+)?["']([^'"]+)["']|\b(?:import|require)\s*\(\s*["']([^'"]+)["']\s*\)/g
 const MAX_PROJECT_PATHS = 15_000
 
 async function openWorkspace({ dialog, userDataPath }) {
@@ -103,12 +101,145 @@ async function addImportLinks(fileNodes, links) {
 function importedSpecifiers(source) {
   const specifiers = []
 
-  for (const match of source.matchAll(IMPORT_SPECIFIER_PATTERN)) {
-    const specifier = match[1] ?? match[2]
-    if (specifier?.startsWith(".")) specifiers.push(specifier)
+  for (let index = 0; index < source.length; ) {
+    const character = source[index]
+
+    if (character === "/" && (source[index + 1] === "/" || source[index + 1] === "*")) {
+      index = skipComment(source, index)
+      continue
+    }
+
+    if (character === "'" || character === '"' || character === "`") {
+      index = skipString(source, index)
+      continue
+    }
+
+    if (!isIdentifierCharacter(character)) {
+      index += 1
+      continue
+    }
+
+    const wordEnd = identifierEnd(source, index)
+    const word = source.slice(index, wordEnd)
+    const match =
+      word === "import"
+        ? importSpecifier(source, wordEnd)
+        : word === "export"
+          ? fromSpecifier(source, wordEnd)
+          : word === "require"
+            ? requireSpecifier(source, wordEnd)
+            : undefined
+
+    if (match?.specifier.startsWith(".")) specifiers.push(match.specifier)
+    index = match?.end ?? wordEnd
   }
 
   return specifiers
+}
+
+function importSpecifier(source, index) {
+  const nextIndex = nextCodeIndex(source, index)
+
+  if (source[nextIndex] === "(") return quotedSpecifier(source, nextCodeIndex(source, nextIndex + 1))
+  if (source[nextIndex] === "'" || source[nextIndex] === '"') return quotedSpecifier(source, nextIndex)
+
+  return fromSpecifier(source, nextIndex)
+}
+
+function requireSpecifier(source, index) {
+  const nextIndex = nextCodeIndex(source, index)
+
+  return source[nextIndex] === "(" ? quotedSpecifier(source, nextCodeIndex(source, nextIndex + 1)) : undefined
+}
+
+function fromSpecifier(source, index) {
+  for (let cursor = index; cursor < source.length; ) {
+    if (source[cursor] === ";") return undefined
+    if (source[cursor] === "/" && (source[cursor + 1] === "/" || source[cursor + 1] === "*")) {
+      cursor = skipComment(source, cursor)
+      continue
+    }
+    if (source[cursor] === "'" || source[cursor] === '"' || source[cursor] === "`") {
+      cursor = skipString(source, cursor)
+      continue
+    }
+    if (!isIdentifierCharacter(source[cursor])) {
+      cursor += 1
+      continue
+    }
+
+    const wordEnd = identifierEnd(source, cursor)
+    if (source.slice(cursor, wordEnd) === "from") return quotedSpecifier(source, nextCodeIndex(source, wordEnd))
+    cursor = wordEnd
+  }
+}
+
+function quotedSpecifier(source, index) {
+  const quote = source[index]
+  if (quote !== "'" && quote !== '"') return undefined
+
+  let specifier = ""
+  for (let cursor = index + 1; cursor < source.length; cursor++) {
+    if (source[cursor] === "\\") {
+      specifier += source[cursor + 1] ?? ""
+      cursor += 1
+      continue
+    }
+    if (source[cursor] === quote) return { specifier, end: cursor + 1 }
+    specifier += source[cursor]
+  }
+}
+
+function nextCodeIndex(source, index) {
+  let cursor = index
+
+  while (cursor < source.length) {
+    if (/\s/.test(source[cursor])) {
+      cursor += 1
+      continue
+    }
+    if (source[cursor] === "/" && (source[cursor + 1] === "/" || source[cursor + 1] === "*")) {
+      cursor = skipComment(source, cursor)
+      continue
+    }
+    break
+  }
+
+  return cursor
+}
+
+function skipComment(source, index) {
+  if (source[index + 1] === "/") {
+    const newlineIndex = source.indexOf("\n", index + 2)
+    return newlineIndex === -1 ? source.length : newlineIndex + 1
+  }
+
+  const commentEnd = source.indexOf("*/", index + 2)
+  return commentEnd === -1 ? source.length : commentEnd + 2
+}
+
+function skipString(source, index) {
+  const quote = source[index]
+
+  for (let cursor = index + 1; cursor < source.length; cursor++) {
+    if (source[cursor] === "\\") {
+      cursor += 1
+      continue
+    }
+    if (source[cursor] === quote) return cursor + 1
+  }
+
+  return source.length
+}
+
+function identifierEnd(source, index) {
+  let cursor = index
+  while (isIdentifierCharacter(source[cursor])) cursor += 1
+  return cursor
+}
+
+function isIdentifierCharacter(character) {
+  return Boolean(character) && /[A-Za-z0-9_$]/.test(character)
 }
 
 function importedFileId(sourcePath, specifier, nodeIdByPath) {

--- a/desktop/workspace.cjs
+++ b/desktop/workspace.cjs
@@ -1,8 +1,12 @@
 const { createHash } = require("node:crypto")
 const { mkdir, readFile, readdir, writeFile } = require("node:fs/promises")
-const { basename, join, relative } = require("node:path")
+const { basename, dirname, extname, join, normalize, relative } = require("node:path")
 
 const GENERATED_DIRECTORIES = new Set([".git", ".vite", "coverage", "dist", "node_modules"])
+const IMPORTABLE_EXTENSIONS = new Set([".cjs", ".cts", ".js", ".jsx", ".mjs", ".mts", ".ts", ".tsx"])
+const IMPORT_PATH_EXTENSIONS = [...IMPORTABLE_EXTENSIONS]
+const IMPORT_SPECIFIER_PATTERN =
+  /\b(?:import|export)\s+(?:[^'"]*?\s+from\s+)?["']([^'"]+)["']|\b(?:import|require)\s*\(\s*["']([^'"]+)["']\s*\)/g
 const MAX_PROJECT_PATHS = 15_000
 
 async function openWorkspace({ dialog, userDataPath }) {
@@ -34,12 +38,14 @@ function workspaceName(rootPath) {
 async function createWorkspaceGraph(rootPath, rootName) {
   const nodes = []
   const links = []
+  const fileNodes = []
   const rootId = `folder:${rootName}`
 
   nodes.push({ id: rootId, label: rootName, type: "folder" })
 
   try {
-    await visitDirectory(rootPath, rootPath, rootId, rootName, nodes, links)
+    await visitDirectory(rootPath, rootPath, rootId, rootName, nodes, links, fileNodes)
+    await addImportLinks(fileNodes, links)
   } catch (error) {
     throw new Error(`Dimension could not read ${rootName}: ${error.message}`)
   }
@@ -47,7 +53,7 @@ async function createWorkspaceGraph(rootPath, rootName) {
   return { nodes, links }
 }
 
-async function visitDirectory(rootPath, directoryPath, parentId, rootName, nodes, links) {
+async function visitDirectory(rootPath, directoryPath, parentId, rootName, nodes, links, fileNodes) {
   const entries = await readdir(directoryPath, { withFileTypes: true })
 
   for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
@@ -59,10 +65,65 @@ async function visitDirectory(rootPath, directoryPath, parentId, rootName, nodes
     const id = `${type}:${rootName}/${path}`
 
     nodes.push({ id, label: entry.name, type })
-    links.push({ source: parentId, target: id })
+    links.push({ source: parentId, target: id, kind: "contains" })
 
-    if (entry.isDirectory()) await visitDirectory(rootPath, join(directoryPath, entry.name), id, rootName, nodes, links)
+    if (entry.isDirectory()) {
+      await visitDirectory(rootPath, join(directoryPath, entry.name), id, rootName, nodes, links, fileNodes)
+    } else if (entry.isFile() && IMPORTABLE_EXTENSIONS.has(extname(entry.name))) {
+      fileNodes.push({ id, path: join(directoryPath, entry.name), relativePath: path })
+    }
   }
+}
+
+async function addImportLinks(fileNodes, links) {
+  const nodeIdByPath = new Map(fileNodes.map((fileNode) => [fileNode.relativePath, fileNode.id]))
+  const linkIds = new Set(links.map((link) => JSON.stringify([link.source, link.target, link.kind ?? "contains"])))
+
+  for (const fileNode of fileNodes) {
+    let source
+
+    try {
+      source = await readFile(fileNode.path, "utf8")
+    } catch {
+      continue
+    }
+    for (const specifier of importedSpecifiers(source)) {
+      const targetId = importedFileId(fileNode.relativePath, specifier, nodeIdByPath)
+      if (!targetId || targetId === fileNode.id) continue
+
+      const linkId = JSON.stringify([fileNode.id, targetId, "imports"])
+      if (linkIds.has(linkId)) continue
+
+      links.push({ source: fileNode.id, target: targetId, kind: "imports" })
+      linkIds.add(linkId)
+    }
+  }
+}
+
+function importedSpecifiers(source) {
+  const specifiers = []
+
+  for (const match of source.matchAll(IMPORT_SPECIFIER_PATTERN)) {
+    const specifier = match[1] ?? match[2]
+    if (specifier?.startsWith(".")) specifiers.push(specifier)
+  }
+
+  return specifiers
+}
+
+function importedFileId(sourcePath, specifier, nodeIdByPath) {
+  const importPath = normalize(join(dirname(sourcePath), specifier)).split("\\").join("/")
+  const importedExtension = extname(importPath)
+  const importPathWithoutExtension = IMPORTABLE_EXTENSIONS.has(importedExtension)
+    ? importPath.slice(0, -importedExtension.length)
+    : importPath
+  const candidatePaths = [
+    importPath,
+    ...IMPORT_PATH_EXTENSIONS.map((extension) => `${importPathWithoutExtension}${extension}`),
+    ...IMPORT_PATH_EXTENSIONS.map((extension) => `${importPath}/index${extension}`),
+  ]
+
+  return candidatePaths.map((path) => nodeIdByPath.get(path)).find(Boolean)
 }
 
 async function persistWorkspaceMetadata(userDataPath, workspace) {

--- a/desktop/workspace.cjs
+++ b/desktop/workspace.cjs
@@ -109,6 +109,11 @@ function importedSpecifiers(source) {
       continue
     }
 
+    if (character === "/" && isRegexStart(source, index)) {
+      index = skipRegex(source, index)
+      continue
+    }
+
     if (character === "'" || character === '"' || character === "`") {
       index = skipString(source, index)
       continue
@@ -227,6 +232,48 @@ function skipString(source, index) {
       continue
     }
     if (source[cursor] === quote) return cursor + 1
+  }
+
+  return source.length
+}
+
+// ponytail: this is a scoped import-hint lexer; use a full parser only if relationship extraction needs complete JavaScript syntax coverage.
+function isRegexStart(source, index) {
+  let previousIndex = index - 1
+
+  while (previousIndex >= 0 && /\s/.test(source[previousIndex])) previousIndex -= 1
+  if (previousIndex < 0 || "=(:,[!&|?;{}+-*%^~<>".includes(source[previousIndex])) return true
+  if (!isIdentifierCharacter(source[previousIndex])) return false
+
+  let wordStart = previousIndex
+  while (wordStart > 0 && isIdentifierCharacter(source[wordStart - 1])) wordStart -= 1
+
+  return ["await", "case", "delete", "do", "else", "in", "instanceof", "new", "of", "return", "throw", "typeof", "void", "yield"].includes(
+    source.slice(wordStart, previousIndex + 1),
+  )
+}
+
+function skipRegex(source, index) {
+  let inCharacterClass = false
+
+  for (let cursor = index + 1; cursor < source.length; cursor++) {
+    if (source[cursor] === "\\") {
+      cursor += 1
+      continue
+    }
+    if (source[cursor] === "[") {
+      inCharacterClass = true
+      continue
+    }
+    if (source[cursor] === "]") {
+      inCharacterClass = false
+      continue
+    }
+    if (source[cursor] === "/" && !inCharacterClass) {
+      while (/[A-Za-z]/.test(source[cursor + 1])) cursor += 1
+      return cursor + 1
+    }
+    if (source[cursor] === "\n") return cursor + 1
   }
 
   return source.length

--- a/desktop/workspace.cjs
+++ b/desktop/workspace.cjs
@@ -164,6 +164,11 @@ function fromSpecifier(source, index) {
       cursor = skipComment(source, cursor)
       continue
     }
+
+    if (source[cursor] === "/" && isRegexStart(source, cursor)) {
+      cursor = skipRegex(source, cursor)
+      continue
+    }
     if (source[cursor] === "'" || source[cursor] === '"' || source[cursor] === "`") {
       cursor = skipString(source, cursor)
       continue

--- a/desktop/workspace.test.cjs
+++ b/desktop/workspace.test.cjs
@@ -39,9 +39,10 @@ test("adds local import links without changing folder containment", async (t) =>
   await mkdir(join(projectRoot, "src", "formatters"), { recursive: true })
   await writeFile(
     join(projectRoot, "src", "app.ts"),
-    'import { format } from "./formatters"\nimport { release } from "./release.test"\n',
+    '// import { ignored } from "./ignored"\n/* require("./ignored") */\nimport {\n  format,\n} from "./formatters"\nimport { release } from "./release.test"\n',
   )
   await writeFile(join(projectRoot, "src", "formatters", "index.ts"), "export const format = () => true\n")
+  await writeFile(join(projectRoot, "src", "ignored.ts"), "export const ignored = true\n")
   await writeFile(join(projectRoot, "src", "release.test.ts"), "export const release = true\n")
 
   const graph = await createWorkspaceGraph(projectRoot, "project")

--- a/desktop/workspace.test.cjs
+++ b/desktop/workspace.test.cjs
@@ -1,5 +1,5 @@
 const assert = require("node:assert/strict")
-const { mkdir, mkdtemp, readFile, rm, writeFile } = require("node:fs/promises")
+const { mkdir, mkdtemp, readFile, rm, symlink, writeFile } = require("node:fs/promises")
 const { tmpdir } = require("node:os")
 const { join } = require("node:path")
 const test = require("node:test")
@@ -29,6 +29,57 @@ test("creates a native project graph and persists metadata outside the root", as
     "file:project/src/app.ts",
   ])
   assert.match(await readFile(join(userDataPath, "workspaces.json"), "utf8"), /"rootPath"/)
+})
+
+test("adds local import links without changing folder containment", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "dimension-workspace-imports-"))
+  t.after(() => rm(temporaryDirectory, { force: true, recursive: true }))
+  const projectRoot = join(temporaryDirectory, "project")
+
+  await mkdir(join(projectRoot, "src", "formatters"), { recursive: true })
+  await writeFile(
+    join(projectRoot, "src", "app.ts"),
+    'import { format } from "./formatters"\nimport { release } from "./release.test"\n',
+  )
+  await writeFile(join(projectRoot, "src", "formatters", "index.ts"), "export const format = () => true\n")
+  await writeFile(join(projectRoot, "src", "release.test.ts"), "export const release = true\n")
+
+  const graph = await createWorkspaceGraph(projectRoot, "project")
+
+  assert.deepEqual(
+    graph.links.filter((link) => link.kind === "imports"),
+    [
+      {
+        source: "file:project/src/app.ts",
+        target: "file:project/src/formatters/index.ts",
+        kind: "imports",
+      },
+      {
+        source: "file:project/src/app.ts",
+        target: "file:project/src/release.test.ts",
+        kind: "imports",
+      },
+    ],
+  )
+  assert.ok(graph.links.some((link) => link.kind === "contains" && link.target === "folder:project/src"))
+})
+
+test("keeps symlinks in the containment map without scanning their target", async (t) => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), "dimension-workspace-symlink-"))
+  t.after(() => rm(temporaryDirectory, { force: true, recursive: true }))
+  const projectRoot = join(temporaryDirectory, "project")
+  const outsideSource = join(temporaryDirectory, "outside.ts")
+
+  await mkdir(join(projectRoot, "src"), { recursive: true })
+  await writeFile(join(projectRoot, "src", "inside.ts"), "export const inside = true\n")
+  await writeFile(outsideSource, 'import { inside } from "./inside"\n')
+  await symlink(outsideSource, join(projectRoot, "src", "linked.ts"))
+
+  const graph = await createWorkspaceGraph(projectRoot, "project")
+
+  assert.ok(graph.nodes.some((node) => node.id === "file:project/src/linked.ts"))
+  assert.ok(graph.links.some((link) => link.kind === "contains" && link.target === "file:project/src/linked.ts"))
+  assert.ok(!graph.links.some((link) => link.source === "file:project/src/linked.ts" && link.kind === "imports"))
 })
 
 test("reports native picker cancellation without reading a project", async () => {

--- a/desktop/workspace.test.cjs
+++ b/desktop/workspace.test.cjs
@@ -39,7 +39,7 @@ test("adds local import links without changing folder containment", async (t) =>
   await mkdir(join(projectRoot, "src", "formatters"), { recursive: true })
   await writeFile(
     join(projectRoot, "src", "app.ts"),
-    '// import { ignored } from "./ignored"\n/* require("./ignored") */\nconst pattern = /import(".\\/ignored")/\nfunction matches() { return /import(".\\/ignored")/ }\nimport {\n  format,\n} from "./formatters"\nimport { release } from "./release.test"\n',
+    '// import { ignored } from "./ignored"\n/* require("./ignored") */\nconst pattern = /import(".\\/ignored")/\nfunction matches() { return /import(".\\/ignored")/ }\nexport const exportedPattern = /from ".\\/ignored"/\nimport {\n  format,\n} from "./formatters"\nimport { release } from "./release.test"\n',
   )
   await writeFile(join(projectRoot, "src", "formatters", "index.ts"), "export const format = () => true\n")
   await writeFile(join(projectRoot, "src", "ignored.ts"), "export const ignored = true\n")

--- a/desktop/workspace.test.cjs
+++ b/desktop/workspace.test.cjs
@@ -39,7 +39,7 @@ test("adds local import links without changing folder containment", async (t) =>
   await mkdir(join(projectRoot, "src", "formatters"), { recursive: true })
   await writeFile(
     join(projectRoot, "src", "app.ts"),
-    '// import { ignored } from "./ignored"\n/* require("./ignored") */\nimport {\n  format,\n} from "./formatters"\nimport { release } from "./release.test"\n',
+    '// import { ignored } from "./ignored"\n/* require("./ignored") */\nconst pattern = /import(".\\/ignored")/\nfunction matches() { return /import(".\\/ignored")/ }\nimport {\n  format,\n} from "./formatters"\nimport { release } from "./release.test"\n',
   )
   await writeFile(join(projectRoot, "src", "formatters", "index.ts"), "export const format = () => true\n")
   await writeFile(join(projectRoot, "src", "ignored.ts"), "export const ignored = true\n")

--- a/web/src/assets/main.css
+++ b/web/src/assets/main.css
@@ -224,6 +224,43 @@ h1 {
   margin: 0;
 }
 
+.relationship-groups {
+  margin: 1.75rem 0 0;
+  padding: 1rem;
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  background: rgba(255, 248, 225, 0.54);
+}
+
+.relationship-groups__chips {
+  list-style: none;
+  margin: 0.55rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.relationship-groups__chips li {
+  margin: 0;
+}
+
+.relationship-groups__chips button {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  background: var(--color-parchment);
+  color: var(--color-heading);
+  cursor: pointer;
+  padding: 0.45rem 0.7rem;
+  font-weight: 700;
+}
+
+.relationship-groups__empty {
+  margin: 0.75rem 0 0;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
 .graph-details h2 {
   margin: 0;
   color: var(--color-heading);
@@ -235,6 +272,7 @@ h1 {
   margin: 0.35rem 0 0;
   color: var(--color-muted);
 }
+
 
 .graph-details__links {
   margin: 0.85rem 0 0;
@@ -309,6 +347,12 @@ h1 {
   stroke: rgba(60, 38, 22, 0.72);
 }
 
+.leyline--import {
+  stroke: var(--color-accent);
+  stroke-dasharray: 4 10;
+  stroke-width: 3;
+}
+
 
 .leyline--context {
   stroke: rgba(85, 54, 30, 0.34);
@@ -375,18 +419,28 @@ h1 {
 
 .rune--context circle:first-child {
   fill: rgba(255, 250, 232, 0.58);
-  stroke: rgba(85, 54, 30, 0.5);
-  stroke-width: 2;
 }
 
-.rune--context text {
-  fill: var(--color-muted);
-  font-size: 0.66rem;
-}
-.rune--policy circle:first-child {
-  fill: rgba(245, 225, 169, 0.88);
+.rune-group__label {
+  pointer-events: none;
+  text-anchor: middle;
+  font-size: 0.62rem;
+  font-weight: 800;
+  fill: #24170f;
+  paint-order: stroke;
+  stroke: rgba(255, 248, 225, 0.92);
+  stroke-width: 2.4;
+  stroke-linejoin: round;
+  letter-spacing: 0.038em;
 }
 
+.rune-group {
+  pointer-events: none;
+  stroke-width: 1.5;
+  stroke-dasharray: 8 8;
+  fill-opacity: 0.06;
+  stroke-opacity: 0.75;
+}
 .rune--async circle:first-child {
   fill: rgba(218, 241, 255, 0.88);
 }

--- a/web/src/components/SpellCanvas.vue
+++ b/web/src/components/SpellCanvas.vue
@@ -4,6 +4,25 @@ import { curveCatmullRom, line } from "d3"
 
 import type { EdgeKind, RuneNode, SpellDiagram } from "@/types/spell-diagram"
 
+interface GroupBoundary {
+  id: string
+  cx: number
+  cy: number
+  rx: number
+  ry: number
+  hue: number
+  label: string
+  lines: string[]
+  labelY: number
+}
+
+const MAX_NODE_LABEL_LINE_LENGTH = 10
+const MAX_NODE_LABEL_LINES = 2
+const MAX_GROUP_LABEL_LINE_LENGTH = 24
+const MAX_GROUP_LABEL_LINES = 2
+const GROUP_LABEL_LINE_HEIGHT = 12
+const GROUP_LABEL_PADDING_Y = 12
+const GROUP_LABEL_PADDING_X = 10
 const props = defineProps<{
   diagram: SpellDiagram
 }>()
@@ -18,6 +37,55 @@ const pathBuilder = line<[number, number]>()
   .x((point: [number, number]) => point[0])
   .y((point: [number, number]) => point[1])
   .curve(curveCatmullRom.alpha(0.5))
+
+const runeBoundaries = computed<GroupBoundary[]>(() => {
+  const byGroup = new Map<string, RuneNode[]>()
+
+  props.diagram.nodes.forEach((node) => {
+    if (node.group) {
+      const nodes = byGroup.get(node.group) ?? []
+      nodes.push(node)
+      byGroup.set(node.group, nodes)
+    }
+  })
+
+  return [...byGroup.entries()]
+    .filter(([, nodes]) => nodes.length > 1)
+    .map(([id, nodes]) => {
+      let minX = Number.POSITIVE_INFINITY
+      let maxX = Number.NEGATIVE_INFINITY
+      let minY = Number.POSITIVE_INFINITY
+      let maxY = Number.NEGATIVE_INFINITY
+
+      nodes.forEach((node) => {
+        const nodeCollisionRadius = node.collisionRadius ?? node.radius
+        minX = Math.min(minX, node.x - nodeCollisionRadius)
+        maxX = Math.max(maxX, node.x + nodeCollisionRadius)
+        minY = Math.min(minY, node.y - nodeCollisionRadius)
+        maxY = Math.max(maxY, node.y + nodeCollisionRadius)
+      })
+
+      const label = resolveGroupLabel(nodes, id)
+      const lines = splitLabelLines(label, MAX_GROUP_LABEL_LINE_LENGTH, MAX_GROUP_LABEL_LINES)
+      const lineHeight = Math.max(1, lines.length) * GROUP_LABEL_LINE_HEIGHT
+      const desiredLabelY = Math.round((minY + maxY) / 2 - lineHeight / 2)
+      const minLabelY = minY + GROUP_LABEL_PADDING_Y
+      const maxLabelY = maxY - GROUP_LABEL_PADDING_Y - lineHeight + 2
+      const labelY = Math.max(minLabelY, Math.min(desiredLabelY, maxLabelY))
+
+      return {
+        id,
+        cx: Math.round((minX + maxX) / 2),
+        cy: Math.round((minY + maxY) / 2),
+        rx: Math.round((maxX - minX) / 2 + 22 + GROUP_LABEL_PADDING_X),
+        ry: Math.round((maxY - minY) / 2 + 16),
+        hue: groupHue(id),
+        label,
+        lines,
+        labelY,
+      }
+    })
+})
 
 const edges = computed(() =>
   props.diagram.edges.flatMap((edge) => {
@@ -36,6 +104,8 @@ const edges = computed(() =>
     ]
   }),
 )
+
+const hasImportEdges = computed(() => props.diagram.edges.some((edge) => edge.kind === "import"))
 
 function buildEdgePath(source: RuneNode, target: RuneNode): string {
   const midpoint: [number, number] = [
@@ -67,12 +137,65 @@ function nodeClass(node: RuneNode): string {
     .join(" ")
 }
 
+function resolveGroupLabel(nodes: RuneNode[], fallback: string): string {
+  return nodes
+    .map((node) => node.groupLabel?.trim())
+    .find(Boolean) ?? `${fallback} (${nodes.length})`
+}
+
 function nodeLabelLines(label: string): string[] {
-  return label
+  return splitLabelLines(label, MAX_NODE_LABEL_LINE_LENGTH, MAX_NODE_LABEL_LINES)
+}
+
+function splitLabelLines(label: string, maxCharsPerLine: number, maxLines: number): string[] {
+  const words = label
     .replace(/([a-z])([A-Z])/g, "$1 $2")
     .split(/[\s_.:/-]+/)
     .filter(Boolean)
-    .slice(0, 2)
+
+  const lines: string[] = []
+
+  for (const word of words) {
+    const token = word.length <= maxCharsPerLine ? word : `${word.slice(0, maxCharsPerLine - 1)}…`
+
+    if (lines.length === 0 || lines[lines.length - 1] === "") {
+      lines.push(token)
+      continue
+    }
+
+    if (lines.length >= maxLines) {
+      const currentLine = lines[maxLines - 1]
+      if (!currentLine.endsWith("…")) {
+        lines[maxLines - 1] = `${currentLine.slice(0, Math.max(3, maxCharsPerLine - 1))}…`
+      }
+      break
+    }
+
+    if (`${lines[lines.length - 1]} ${token}`.length <= maxCharsPerLine) {
+      lines[lines.length - 1] = `${lines[lines.length - 1]} ${token}`
+      continue
+    }
+
+    lines.push(token)
+  }
+
+  if (lines.length === 0) return []
+  const compact = lines.slice(0, maxLines)
+  const last = compact[compact.length - 1]
+
+  if (lines.length > maxLines && !last.endsWith("…")) {
+    compact[compact.length - 1] = `${last.slice(0, Math.max(3, maxCharsPerLine - 1))}…`
+  }
+
+  return compact
+}
+
+function groupHue(value: string): number {
+  let hash = 0
+  for (const char of value) {
+    hash = (hash * 13 + char.charCodeAt(0)) % 360
+  }
+  return hash
 }
 </script>
 
@@ -103,6 +226,34 @@ function nodeLabelLines(label: string): string[] {
       <rect class="parchment" x="24" y="24" width="1032" height="672" rx="34" />
       <circle class="scope-ring scope-ring--outer" cx="540" cy="360" r="300" />
       <circle class="scope-ring scope-ring--inner" cx="540" cy="360" r="188" />
+
+      <g class="rune-groups">
+        <ellipse
+          v-for="group in runeBoundaries"
+          :key="group.id"
+          class="rune-group"
+          :cx="group.cx"
+          :cy="group.cy"
+          :rx="group.rx"
+          :ry="group.ry"
+          :style="{ stroke: `hsla(${group.hue}, 68%, 35%, 0.4)`, fill: `hsla(${group.hue}, 70%, 44%, 0.1)` }"
+        />
+        <text
+          v-for="group in runeBoundaries"
+          :key="`label-${group.id}`"
+          class="rune-group__label"
+          :x="group.cx"
+          :y="group.labelY"
+          text-anchor="middle"
+          dominant-baseline="hanging"
+          :style="{ fill: `hsl(${group.hue}, 40%, 16%)` }"
+        >
+          <tspan v-for="(line, index) in group.lines" :key="`label-${group.id}-${index}`" :x="group.cx" :dy="index ? 14 : 0">
+            {{ line }}
+          </tspan>
+        </text>
+      </g>
+
 
       <g class="leylines" filter="url(#ink-bleed)">
         <path
@@ -147,6 +298,8 @@ function nodeLabelLines(label: string): string[] {
     <figcaption>
       <strong>{{ diagram.title }}</strong>
       <span>{{ diagram.subtitle }}</span>
+      <small v-if="hasImportEdges" class="relationship-key">Solid lines: containment · dashed orange lines: local imports</small>
     </figcaption>
   </figure>
+
 </template>

--- a/web/src/services/spell-diagram-adapter.ts
+++ b/web/src/services/spell-diagram-adapter.ts
@@ -1,17 +1,40 @@
 import type { SourceGraph, SourceLink, SourceNode } from "@/types/source-graph"
 import type { EdgeKind, RuneKind, RuneNode, SpellDiagram } from "@/types/spell-diagram"
 
+const TAU = Math.PI * 2
+const GOLDEN_ANGLE = Math.PI * (3 - Math.sqrt(5))
+
 const CANVAS_WIDTH = 1080
 const CANVAS_HEIGHT = 720
 const CENTER_X = CANVAS_WIDTH / 2
 const CENTER_Y = CANVAS_HEIGHT / 2
+const CANVAS_PADDING = 56
 const LAYOUT_RADIUS_X = 300
 const LAYOUT_RADIUS_Y = 205
 const DENSE_GRAPH_LIMIT = 28
 const CONTEXT_X = 175
-const CONTEXT_START_Y = 150
-const CONTEXT_GAP_Y = 72
+const CONTEXT_GAP_Y = 120
+const CONTEXT_MAX_PER_COLUMN = 8
+const CONTEXT_COLUMN_SPACING = 145
+const DETAIL_GROUP_PADDING = 16
 const DETAIL_LIMIT = 14
+const DETAIL_GROUP_TARGET_SIZE = 8
+const DETAIL_GROUP_BUCKET_MAX = 5
+const GROUP_ORBIT_X = 300
+const GROUP_ORBIT_Y = 165
+const GROUP_RING_BASE_RADIUS = 56
+const GROUP_RING_STEP = 36
+const COLLISION_PASSES = 320
+const ANCHOR_PULL = 0.009
+const MIN_MOVE = 0.001
+const GROUP_RING_SPAN = TAU
+const LABEL_COLLISION_MAX_CHARS = 10
+const LABEL_COLLISION_MAX_LINES = 2
+const LABEL_COLLISION_CHAR_WIDTH = 7.2
+const LABEL_COLLISION_LINE_HEIGHT = 16
+const LABEL_COLLISION_PADDING = 8
+
+type DetailLayout = { x: number; y: number; group: string; groupLabel: string }
 
 export interface SpellDiagramInput {
   graph: SourceGraph
@@ -21,49 +44,84 @@ export interface SpellDiagramInput {
 }
 
 export function createSpellDiagramFromSourceGraph(input: SpellDiagramInput): SpellDiagram {
-  const sourceNodes = input.graph.nodes.length > 0 ? input.graph.nodes : [emptySourceNode()]
+  const sourceNodes = uniqueSourceNodesById(input.graph.nodes.length > 0 ? input.graph.nodes : [emptySourceNode()])
   const focusNode = focusNodeFor(sourceNodes, input.selectedNodeId)
-  const visibleNodes = visibleSourceNodes(sourceNodes, input.graph.links, focusNode)
+  const visibleNodes = uniqueSourceNodesById(visibleSourceNodes(sourceNodes, input.graph.links, focusNode))
   const visibleNodeIds = new Set(visibleNodes.map((node) => node.id))
   const hiddenCount = sourceNodes.length - visibleNodes.length
   const subtitle =
     hiddenCount > 0
       ? `${input.subtitle} Showing ${visibleNodes.length} of ${sourceNodes.length}; click a linked rune to refocus.`
       : input.subtitle
+  const detailLayouts = layoutDetailNodes(visibleNodes, input.graph.links, focusNode)
+  const contextIndexes = new Map<string, number>()
+  const detailIndexes = new Map<string, number>()
+
+  visibleNodes.forEach((node) => {
+    if (node.type === "context") {
+      contextIndexes.set(node.id, contextIndexes.size)
+      return
+    }
+
+    if (node.id !== focusNode.id) {
+      detailIndexes.set(node.id, detailIndexes.size)
+    }
+  })
+
+  const nodes = visibleNodes.map((node, index) =>
+    createRuneNode(
+      node,
+      index,
+      visibleNodes.length,
+      node.id === focusNode.id,
+      node.id === input.selectedNodeId,
+      contextIndexes.get(node.id) ?? 0,
+      contextCount(visibleNodes),
+      detailIndexes.get(node.id) ?? 0,
+      detailIndexes.size,
+      detailLayouts.get(node.id),
+    ),
+  )
+
+  const fixedNodeIds = new Set<string>(
+    visibleNodes
+      .filter((node) => node.id === focusNode.id || node.type === "context")
+      .map((node) => node.id),
+  )
+  const anchorsByNodeId = new Map<string, { x: number; y: number }>()
+  detailLayouts.forEach((layout, nodeId) => {
+    anchorsByNodeId.set(nodeId, { x: layout.x, y: layout.y })
+  })
+
+  resolveOverlaps(nodes, fixedNodeIds, anchorsByNodeId)
+
+  const edges: SpellDiagram["edges"] = []
+  const edgeIds = new Set<string>()
+
+  input.graph.links.forEach((link) => {
+    const edgeId = JSON.stringify([link.source, link.target, link.kind ?? "contains"])
+
+    if (!visibleNodeIds.has(link.source) || !visibleNodeIds.has(link.target)) return
+    if (edgeIds.has(edgeId)) return
+
+    const source = visibleNodes.find((node) => node.id === link.source)
+    const target = visibleNodes.find((node) => node.id === link.target)
+    if (source?.type === "context" && target?.type === "context") return
+
+    edges.push({
+      id: edgeId,
+      source: link.source,
+      target: link.target,
+      kind: edgeKindFor(link, source, target),
+    })
+    edgeIds.add(edgeId)
+  })
 
   return {
     title: input.title,
     subtitle,
-    nodes: visibleNodes.map((node, index) =>
-      createRuneNode(
-        node,
-        index,
-        visibleNodes.length,
-        node.id === focusNode.id,
-        node.id === input.selectedNodeId,
-        contextIndex(visibleNodes, index),
-        contextCount(visibleNodes),
-        detailIndex(visibleNodes, index),
-        detailCount(visibleNodes),
-      ),
-    ),
-    edges: input.graph.links
-      .filter((link) => visibleNodeIds.has(link.source) && visibleNodeIds.has(link.target))
-      .flatMap((link, index) => {
-        const source = visibleNodes.find((node) => node.id === link.source)
-        const target = visibleNodes.find((node) => node.id === link.target)
-
-        if (source?.type === "context" && target?.type === "context") return []
-
-        return [
-          {
-            id: `${link.source}-${link.target}-${index}`,
-            source: link.source,
-            target: link.target,
-            kind: edgeKindFor(source, target),
-          },
-        ]
-      }),
+    nodes,
+    edges,
   }
 }
 
@@ -78,25 +136,54 @@ function visibleSourceNodes(nodes: SourceNode[], links: SourceLink[], focusNode:
   const directIds = linkedNodeIds(links, focusNode.id)
   parentNodes.forEach((node) => directIds.delete(node.id))
 
-  const siblingNodes = siblingMethodIds(nodes, links, focusNode)
+  const siblingIds = siblingMethodIds(nodes, links, focusNode).slice(0, 6)
+  const siblingNodes = siblingIds
     .map((id) => nodes.find((node) => node.id === id))
     .filter((node): node is SourceNode => Boolean(node))
-    .slice(0, 6)
     .map(asContextNode)
-
+  siblingIds.forEach((id) => directIds.delete(id))
   const detailNodes = nodes.filter((node) => directIds.has(node.id)).slice(0, DETAIL_LIMIT)
 
-  return [focusNode, ...parentNodes.map(asContextNode), ...siblingNodes, ...detailNodes]
+  return uniqueSourceNodesById([focusNode, ...parentNodes.map(asContextNode), ...siblingNodes, ...detailNodes])
 }
 
 function firstLayerNodes(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): SourceNode[] {
-  const visibleIds = linkedNodeIds(links, focusNode.id)
+  const childIds = new Set(
+    links
+      .filter((link) => link.kind !== "imports" && link.source === focusNode.id)
+      .map((link) => link.target),
+  )
+  const importIds =
+    focusNode.type === "file"
+      ? new Set(
+          links
+            .filter(
+              (link) => link.kind === "imports" && (link.source === focusNode.id || link.target === focusNode.id),
+            )
+            .map((link) => (link.source === focusNode.id ? link.target : link.source)),
+        )
+      : new Set<string>()
+  const childNodes = nodes.filter((node) => childIds.has(node.id))
+  const importNodes = nodes.filter((node) => importIds.has(node.id))
 
-  return [focusNode, ...nodes.filter((node) => visibleIds.has(node.id))].slice(0, DENSE_GRAPH_LIMIT)
+  return uniqueSourceNodesById([focusNode, ...childNodes, ...importNodes]).slice(0, DENSE_GRAPH_LIMIT)
 }
 
 function isLayerNode(node: SourceNode): boolean {
   return node.type === "class" || node.type === "file" || node.type === "folder"
+}
+
+function uniqueSourceNodesById(nodes: SourceNode[]): SourceNode[] {
+  const seen = new Set<string>()
+  const deduped: SourceNode[] = []
+
+  nodes.forEach((node) => {
+    if (seen.has(node.id)) return
+    seen.add(node.id)
+    deduped.push(node)
+  })
+
+  return deduped
 }
 
 function linkedNodeIds(links: SourceLink[], nodeId: string): Set<string> {
@@ -113,18 +200,27 @@ function linkedNodeIds(links: SourceLink[], nodeId: string): Set<string> {
 function siblingMethodIds(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): string[] {
   if (!focusNode.id.includes(":method:")) return []
 
-  const parentIds = links.filter((link) => link.target === focusNode.id).map((link) => link.source)
+  const containmentLinks = links.filter((link) => link.kind !== "imports")
+  const parentIds = containmentLinks.filter((link) => link.target === focusNode.id).map((link) => link.source)
+  const siblingIds = new Set<string>()
 
-  return links
-    .filter((link) => parentIds.includes(link.source) && link.target !== focusNode.id)
-    .map((link) => nodes.find((node) => node.id === link.target))
-    .filter((node): node is SourceNode => Boolean(node && node.id.includes(":method:")))
-    .map((node) => node.id)
+  containmentLinks.forEach((link) => {
+    if (!parentIds.includes(link.source) || link.target === focusNode.id) return
+
+    const siblingNode = nodes.find((node) => node.id === link.target)
+    if (!siblingNode || !siblingNode.id.includes(":method:")) return
+
+    siblingIds.add(siblingNode.id)
+  })
+
+  return [...siblingIds].slice(0, 6)
 }
+
+
 
 function parentContextNodes(nodes: SourceNode[], links: SourceLink[], focusNode: SourceNode): SourceNode[] {
   return links
-    .filter((link) => link.target === focusNode.id)
+    .filter((link) => link.kind !== "imports" && link.target === focusNode.id)
     .map((link) => nodes.find((node) => node.id === link.source))
     .filter((node): node is SourceNode => Boolean(node))
     .slice(0, 1)
@@ -137,20 +233,450 @@ function asContextNode(node: SourceNode): SourceNode {
   }
 }
 
+function layoutDetailNodes(
+  visibleNodes: SourceNode[],
+  links: SourceLink[],
+  focusNode: SourceNode,
+): Map<string, DetailLayout> {
+  const detailNodes = visibleNodes.filter((node) => node.id !== focusNode.id && node.type !== "context")
+  if (detailNodes.length === 0) return new Map()
+
+  const grouped = groupByRelationship(detailNodes, links, focusNode)
+  const groupedWithLabels = new Map<string, { members: SourceNode[]; label: string }>()
+
+  grouped.forEach((members, groupId) => {
+    const groupLabel = relationshipGroupLabel(groupId)
+
+    if (members.length <= DETAIL_GROUP_TARGET_SIZE) {
+      groupedWithLabels.set(groupId, { members, label: groupLabel })
+      return
+    }
+
+    const bucketedGroups = splitRelationshipGroup(groupId, members)
+    bucketedGroups.forEach((bucketMembers, bucketId) => {
+      const bucketLabel = `${groupLabel} batch ${bucketIndexFromGroupId(bucketId)}`
+      groupedWithLabels.set(bucketId, { members: bucketMembers, label: bucketLabel })
+    })
+  })
+
+  const anchorInputs = new Map<string, SourceNode[]>()
+  groupedWithLabels.forEach((value, groupId) => anchorInputs.set(groupId, value.members))
+  const anchors = groupAnchors(anchorInputs)
+  const layouts = new Map<string, DetailLayout>()
+
+  groupedWithLabels.forEach((group, groupId) => {
+    const members = group.members.toSorted((left, right) => {
+      if (left.type !== right.type) return left.type.localeCompare(right.type)
+      return left.label.localeCompare(right.label)
+    })
+    const anchor = anchors.get(groupId)
+    if (!anchor || members.length === 0) return
+
+    const groupNodeRadius = maxNodeRadius(members)
+    const nodeSpacing = groupNodeRadius * 2 + DETAIL_GROUP_PADDING * 2.2
+    const anchorAngle = Math.atan2(anchor.y - CENTER_Y, anchor.x - CENTER_X)
+    const ringRadiusStep = Math.max(GROUP_RING_STEP, groupNodeRadius * 2 + DETAIL_GROUP_PADDING * 1.2)
+    const minCenterDistance = groupNodeRadius * 2 + DETAIL_GROUP_PADDING
+    let cursor = 0
+    let ring = 0
+
+    while (cursor < members.length) {
+      const projectedRingRadius = GROUP_RING_BASE_RADIUS + ring * ringRadiusStep
+      const ringAngleSpan = GROUP_RING_SPAN
+      const estimatedCount = Math.min(
+        Math.max(1, Math.floor((ringAngleSpan * projectedRingRadius) / (nodeSpacing * 1.12))),
+        members.length - cursor,
+      )
+      const ringRadius =
+        estimatedCount <= 1
+          ? projectedRingRadius
+          : Math.max(
+              projectedRingRadius,
+              minCenterDistance / (2 * Math.sin(ringAngleSpan / (2 * Math.max(2, estimatedCount)))),
+            )
+      const ringCapacity = Math.min(
+        Math.floor((ringAngleSpan * ringRadius) / (nodeSpacing * 1.12)),
+        members.length - cursor,
+      )
+      const count = Math.max(1, Math.min(ringCapacity, estimatedCount))
+      const arcStart = anchorAngle + GOLDEN_ANGLE * ring
+
+      for (let i = 0; i < count; i++) {
+        const node = members[cursor + i]
+        const localAngle =
+          count === 1
+            ? 0
+            : Math.abs(ringAngleSpan - TAU) < 0.0001
+              ? (i / count) * TAU + (ring % 2 ? TAU / (2 * count) : 0)
+              : ((i + (ring % 2 ? 0.5 : 0)) / (count - 1) - 0.5) * ringAngleSpan
+        const angle = arcStart + localAngle
+        layouts.set(node.id, {
+          x: anchor.x + Math.cos(angle) * ringRadius,
+          y: anchor.y + Math.sin(angle) * ringRadius,
+          group: groupId,
+          groupLabel: `${group.label}`.trim(),
+        })
+      }
+
+      cursor += count
+      ring += 1
+    }
+  })
+
+  return layouts
+}
+
+function relationshipGroupLabel(groupId: string): string {
+  const baseGroupId = stripBucketSuffix(groupId)
+  const parsed = parseRelationshipGroup(baseGroupId)
+  const parentLabel = formatNodeLabel(parsed.parentId)
+
+  if (parsed.relationshipKind === "imports") return `Imports near ${parentLabel}`
+
+  return `${pluralizeNodeType(parsed.nodeType)} from ${parentLabel}`
+}
+
+function bucketIndexFromGroupId(groupId: string): number {
+  const bucketIndexMatch = groupId.match(/:bucket:(\d+)$/)
+  if (!bucketIndexMatch) return 1
+
+  return Number(bucketIndexMatch[1]) || 1
+}
+
+function pluralizeNodeType(nodeType: string): string {
+  if (nodeType.endsWith("s")) return nodeType
+  return `${nodeType}s`
+}
+
+function stripBucketSuffix(groupId: string): string {
+  const match = groupId.match(/(.+):bucket:\d+$/)
+  if (!match) return groupId
+
+  return match[1]
+}
+
+function parseRelationshipGroup(groupId: string): {
+  parentId: string
+  relationshipKind: "contains" | "imports"
+  nodeType: string
+} {
+  const relationshipKind = groupId.startsWith("imports:") ? "imports" : "contains"
+  const groupWithoutKind = groupId.slice(`${relationshipKind}:`.length)
+  const delimiterIndex = groupWithoutKind.lastIndexOf(":")
+
+  if (delimiterIndex <= 0 || delimiterIndex === groupWithoutKind.length - 1) {
+    return { parentId: "root", relationshipKind, nodeType: "item" }
+  }
+
+  return {
+    parentId: groupWithoutKind.slice(0, delimiterIndex),
+    relationshipKind,
+    nodeType: groupWithoutKind.slice(delimiterIndex + 1),
+  }
+}
+
+function formatNodeLabel(nodeId: string): string {
+  const path = nodeId.includes(":") ? nodeId.split(":").slice(1).join(":") : nodeId
+  const segments = path.split("/").filter(Boolean)
+
+  const parentLabel = segments.at(-1) || path
+
+  return parentLabel || "root"
+}
+function maxNodeRadius(nodes: SourceNode[]): number {
+  let radius = 0
+
+  nodes.forEach((node) => {
+    const nextRadius = radiusForSourceType(node.type, false)
+    if (nextRadius > radius) radius = nextRadius
+  })
+
+  return Math.max(1, radius)
+}
+
+function groupByRelationship(
+  detailNodes: SourceNode[],
+  links: SourceLink[],
+  focusNode: SourceNode,
+): Map<string, SourceNode[]> {
+  const byTypeAndParent = new Map<string, SourceNode[]>()
+
+  for (const node of detailNodes) {
+    const directRelationship = links.find(
+      (link) =>
+        (link.source === focusNode.id && link.target === node.id) ||
+        (link.target === focusNode.id && link.source === node.id),
+    )
+    const incomingRelationship = links.find((link) => link.target === node.id)
+    const relationship = directRelationship ?? incomingRelationship
+    const parentId = directRelationship ? focusNode.id : relationship?.source ?? focusNode.id
+    const relationshipKind = relationship?.kind === "imports" ? "imports" : "contains"
+    const relationshipGroupId = `${relationshipKind}:${parentId}:${node.type}`
+    const members = byTypeAndParent.get(relationshipGroupId) ?? []
+    members.push(node)
+    byTypeAndParent.set(relationshipGroupId, members)
+  }
+
+  const grouped = new Map<string, SourceNode[]>()
+  byTypeAndParent.forEach((members, groupId) => {
+    if (members.length <= DETAIL_GROUP_TARGET_SIZE) {
+      grouped.set(groupId, members)
+      return
+    }
+
+    splitRelationshipGroup(groupId, members).forEach((bucketMembers, bucketId) => {
+      grouped.set(bucketId, bucketMembers)
+    })
+  })
+
+  return grouped
+}
+
+function splitRelationshipGroup(groupId: string, members: SourceNode[]): Map<string, SourceNode[]> {
+  const sortedMembers = members.toSorted((left, right) => left.label.localeCompare(right.label))
+  const bucketCount = Math.min(Math.ceil(sortedMembers.length / DETAIL_GROUP_TARGET_SIZE), DETAIL_GROUP_BUCKET_MAX)
+  const bucketSize = Math.ceil(sortedMembers.length / bucketCount)
+  const grouped = new Map<string, SourceNode[]>()
+
+  sortedMembers.forEach((member, index) => {
+    const bucketIndex = Math.min(Math.floor(index / bucketSize), bucketCount - 1)
+    const bucketId = `${groupId}:bucket:${bucketIndex + 1}`
+    const bucketMembers = grouped.get(bucketId) ?? []
+    grouped.set(bucketId, [...bucketMembers, member])
+  })
+
+  return grouped
+}
+
+function maxNodeRadiusByGroups(groups: Map<string, SourceNode[]>): number {
+  let radius = 0
+
+  groups.forEach((nodes) => {
+    const groupRadius = maxNodeRadius(nodes)
+    if (groupRadius > radius) radius = groupRadius
+  })
+
+  return Math.max(1, radius)
+}
+
+function groupAnchors(grouped: Map<string, SourceNode[]>): Map<string, { x: number; y: number }> {
+  const anchors = new Map<string, { x: number; y: number }>()
+  const groupIds = [...grouped.keys()]
+  const groupCount = groupIds.length
+  if (groupCount === 0) return anchors
+
+  if (groupCount === 1) {
+    const singleGroupId = groupIds[0]
+    const singleGroup = grouped.get(singleGroupId) ?? []
+    const singleGroupRadius = maxNodeRadius(singleGroup)
+    const singleGroupX = CANVAS_WIDTH - CANVAS_PADDING - singleGroupRadius - DETAIL_GROUP_PADDING
+    const yOffset = clamp(
+      DETAIL_GROUP_PADDING + singleGroupRadius / 2 + Math.min(92, singleGroup.length * 4.8),
+      40,
+      GROUP_ORBIT_Y * 1.35,
+    )
+    const singleGroupY = clamp(
+      CENTER_Y - yOffset,
+      CANVAS_PADDING + singleGroupRadius + DETAIL_GROUP_PADDING,
+      CANVAS_HEIGHT - CANVAS_PADDING - singleGroupRadius - DETAIL_GROUP_PADDING,
+    )
+
+    anchors.set(singleGroupId, { x: singleGroupX, y: singleGroupY })
+    return anchors
+  }
+
+  const maxNodeRadiusValue = maxNodeRadiusByGroups(grouped)
+  const minCenterDistance = maxNodeRadiusValue * 2 + DETAIL_GROUP_PADDING
+  const xClearance = CANVAS_PADDING + maxNodeRadiusValue + DETAIL_GROUP_PADDING
+  const yClearance = CANVAS_PADDING + maxNodeRadiusValue + DETAIL_GROUP_PADDING
+  const maxOrbitX = Math.max(
+    140,
+    Math.min(
+      GROUP_ORBIT_X,
+      Math.min(CENTER_X - xClearance, CANVAS_WIDTH - xClearance - CENTER_X),
+    ),
+  )
+  const maxOrbitY = Math.max(
+    90,
+    Math.min(
+      GROUP_ORBIT_Y,
+      Math.min(CENTER_Y - yClearance, CANVAS_HEIGHT - yClearance - CENTER_Y),
+    ),
+  )
+  const orbitX = Math.min(maxOrbitX, Math.max(150, (minCenterDistance * groupCount) / TAU))
+  const orbitY = Math.min(maxOrbitY, Math.max(90, orbitX * 0.58))
+
+  groupIds.forEach((groupId, index) => {
+    const angle = (TAU * index) / groupCount - Math.PI / 2 + GOLDEN_ANGLE * 0.3
+    anchors.set(groupId, {
+      x: clamp(CENTER_X + Math.cos(angle) * orbitX, CANVAS_PADDING, CANVAS_WIDTH - CANVAS_PADDING),
+      y: clamp(CENTER_Y + Math.sin(angle) * orbitY, CANVAS_PADDING, CANVAS_HEIGHT - CANVAS_PADDING),
+    })
+  })
+
+  return anchors
+}
+
+function resolveOverlaps(
+  nodes: RuneNode[],
+  fixedNodeIds: Set<string>,
+  anchorsByNodeId: Map<string, { x: number; y: number }>,
+): void {
+  if (nodes.length < 2) return
+
+  const movableNodes = nodes.filter((node) => !fixedNodeIds.has(node.id))
+  if (movableNodes.length === 0) return
+  if (anchorsByNodeId.size === 0) return
+
+  const collisionRadii = new Map<string, number>(
+    nodes.map((node) => [node.id, collisionRadiusForRune(node)]),
+  )
+
+  for (let pass = 0; pass < COLLISION_PASSES; pass++) {
+    let moved = 0
+    const deltas = new Map<string, { x: number; y: number }>()
+
+    movableNodes.forEach((node) => {
+      deltas.set(node.id, { x: 0, y: 0 })
+    })
+
+    for (let i = 0; i < nodes.length; i++) {
+      const source = nodes[i]
+      const sourceFixed = fixedNodeIds.has(source.id)
+      const sourceDelta = sourceFixed ? undefined : deltas.get(source.id)
+      const sourceCollisionRadius = collisionRadii.get(source.id)
+
+      for (let j = i + 1; j < nodes.length; j++) {
+        const target = nodes[j]
+        const targetFixed = fixedNodeIds.has(target.id)
+        const targetDelta = targetFixed ? undefined : deltas.get(target.id)
+        const targetCollisionRadius = collisionRadii.get(target.id)
+
+        if (sourceFixed && targetFixed) continue
+
+        const dx = target.x - source.x
+        const dy = target.y - source.y
+        const minDistance =
+          (sourceCollisionRadius ?? source.radius) + (targetCollisionRadius ?? target.radius) + DETAIL_GROUP_PADDING
+        const minDistanceSq = minDistance * minDistance
+        const actualDistanceSq = dx * dx + dy * dy
+        if (actualDistanceSq >= minDistanceSq) continue
+
+        const actualDistance = Math.sqrt(Math.max(0.0001, actualDistanceSq))
+        const bothMovable = Boolean(sourceDelta) && Boolean(targetDelta)
+        const overlap = (minDistance - actualDistance) / (bothMovable ? 2 : 1)
+        if (overlap <= 0) continue
+
+        let unitX = dx
+        let unitY = dy
+
+        if (actualDistanceSq === 0) {
+          const driftAngle = deterministicAngle(source.id, target.id)
+          unitX = Math.cos(driftAngle)
+          unitY = Math.sin(driftAngle)
+        } else {
+          unitX /= actualDistance
+          unitY /= actualDistance
+        }
+
+        if (sourceDelta) {
+          sourceDelta.x -= unitX * overlap
+          sourceDelta.y -= unitY * overlap
+          moved += Math.abs(unitX * overlap) + Math.abs(unitY * overlap)
+        }
+
+        if (targetDelta) {
+          targetDelta.x += unitX * overlap
+          targetDelta.y += unitY * overlap
+          moved += Math.abs(unitX * overlap) + Math.abs(unitY * overlap)
+        }
+      }
+    }
+
+    const shouldSettle = moved < MIN_MOVE || pass === COLLISION_PASSES - 1
+
+    movableNodes.forEach((node) => {
+      const delta = deltas.get(node.id)
+      if (!delta) return
+
+      const anchor = anchorsByNodeId.get(node.id)
+      if (anchor && !shouldSettle) {
+        delta.x += (anchor.x - node.x) * ANCHOR_PULL
+        delta.y += (anchor.y - node.y) * ANCHOR_PULL
+      }
+
+      const nodeCollisionRadius = collisionRadii.get(node.id) ?? node.radius
+      node.x = clamp(node.x + delta.x, CANVAS_PADDING + nodeCollisionRadius, CANVAS_WIDTH - CANVAS_PADDING - nodeCollisionRadius)
+      node.y = clamp(node.y + delta.y, CANVAS_PADDING + nodeCollisionRadius, CANVAS_HEIGHT - CANVAS_PADDING - nodeCollisionRadius)
+    })
+
+    if (shouldSettle) break
+  }
+}
+
+function deterministicAngle(left: string, right: string): number {
+  let hash = 0
+  for (const char of left) {
+    hash = (hash * 31 + char.charCodeAt(0)) % 360
+  }
+  for (const char of right) {
+    hash = (hash * 31 + char.charCodeAt(0)) % 360
+  }
+  return (hash / 360) * TAU
+}
+
+function collisionRadiusForRune(node: RuneNode): number {
+  return collisionRadiusForLabel(node.label, node.radius)
+}
+
+function collisionRadiusForLabel(label: string, baseRadius: number): number {
+  const lines = splitLabelForCollision(label, LABEL_COLLISION_MAX_CHARS, LABEL_COLLISION_MAX_LINES)
+  if (lines.length === 0) return baseRadius + LABEL_COLLISION_PADDING
+
+  const maxLineLength = lines.reduce((currentMax, line) => Math.max(currentMax, line.length), 0)
+  const estimatedTextHalfWidth = (maxLineLength * LABEL_COLLISION_CHAR_WIDTH) / 2
+  const estimatedTextHalfHeight = (lines.length * LABEL_COLLISION_LINE_HEIGHT) / 2
+
+  return Math.max(baseRadius, estimatedTextHalfWidth, estimatedTextHalfHeight) + LABEL_COLLISION_PADDING
+}
+
+function splitLabelForCollision(label: string, maxCharsPerLine: number, maxLines: number): string[] {
+  const words = label
+    .replace(/([a-z])([A-Z])/g, "$1 $2")
+    .split(/[\s_.:/-]+/)
+    .filter(Boolean)
+
+  const lines: string[] = []
+
+  for (const word of words) {
+    const token = word.length <= maxCharsPerLine ? word : `${word.slice(0, Math.max(1, maxCharsPerLine - 1))}…`
+
+    if (lines.length === 0) {
+      lines.push(token)
+      continue
+    }
+
+    if (lines.length >= maxLines) {
+      const last = lines[maxLines - 1]
+      if (!last.endsWith("…")) {
+        lines[maxLines - 1] = `${last.slice(0, Math.max(1, maxCharsPerLine - 1))}…`
+      }
+      break
+    }
+
+    if (`${lines[lines.length - 1]} ${token}`.length <= maxCharsPerLine) {
+      lines[lines.length - 1] = `${lines[lines.length - 1]} ${token}`
+      continue
+    }
+
+    lines.push(token)
+  }
+
+  return lines
+}
+
 function contextCount(nodes: SourceNode[]): number {
   return nodes.filter((node) => node.type === "context").length
-}
-
-function contextIndex(nodes: SourceNode[], index: number): number {
-  return nodes.slice(0, index).filter((node) => node.type === "context").length
-}
-
-function detailCount(nodes: SourceNode[]): number {
-  return nodes.filter((node) => node.type !== "context").length - 1
-}
-
-function detailIndex(nodes: SourceNode[], index: number): number {
-  return nodes.slice(0, index).filter((node) => node.type !== "context").length - 1
 }
 
 function createRuneNode(
@@ -163,46 +689,88 @@ function createRuneNode(
   nodeContextCount: number,
   nodeDetailIndex: number,
   nodeDetailCount: number,
+  detailLayout?: DetailLayout,
 ): RuneNode {
   if (isFocus) {
+    const radius = radiusForSourceType(node.type, true)
+
     return {
       id: node.id,
       label: node.label,
       kind: runeKindForSourceType(node.type),
       x: CENTER_X,
       y: CENTER_Y,
-      radius: radiusForSourceType(node.type, true),
+      radius,
       ring: "focus",
       isSelected,
+      collisionRadius: collisionRadiusForLabel(node.label, radius),
     }
   }
 
   if (node.type === "context") {
+    const contextRadius = radiusForSourceType(node.type, false)
+    const contextRows = Math.min(nodeContextCount, CONTEXT_MAX_PER_COLUMN)
+    const contextColumns = Math.max(1, Math.ceil(nodeContextCount / CONTEXT_MAX_PER_COLUMN))
+    const contextRow = contextRows > 0 ? nodeContextIndex % contextRows : 0
+    const contextColumn = contextRows > 0 ? Math.floor(nodeContextIndex / contextRows) : 0
+    const contextRowSpan = Math.max(1, (CANVAS_HEIGHT - CANVAS_PADDING * 2) - contextRadius * 2)
+    const contextGapY =
+      contextRows <= 1 ? 0 : Math.min(CONTEXT_GAP_Y, contextRowSpan / Math.max(contextRows - 1, 1))
+    const contextCenterOffset = contextRows <= 1 ? 0 : (contextRow - (contextRows - 1) / 2) * contextGapY
+    const contextColumnSpan = contextColumns <= 1 ? 0 : Math.max(1, contextColumns - 1)
+    const contextColumnGap =
+      contextColumns <= 1
+        ? 0
+        : Math.min(CONTEXT_COLUMN_SPACING, (CANVAS_WIDTH - CANVAS_PADDING * 2 - contextRadius * 2) / contextColumnSpan)
+    const contextRawStartX = CONTEXT_X - ((contextColumns - 1) * contextColumnGap) / 2
+    const contextShiftX = Math.max(0, CANVAS_PADDING + contextRadius - contextRawStartX)
+    const contextX = Math.min(
+      CANVAS_WIDTH - CANVAS_PADDING - contextRadius,
+      Math.round(contextRawStartX + contextShiftX + contextColumn * contextColumnGap),
+    )
+
     return {
       id: node.id,
       label: node.label,
       kind: "context",
-      x: CONTEXT_X,
-      y: CONTEXT_START_Y + nodeContextIndex * Math.min(CONTEXT_GAP_Y, 500 / Math.max(nodeContextCount, 1)),
-      radius: radiusForSourceType(node.type, false),
+      x: contextX,
+      y: Math.round(CENTER_Y + contextCenterOffset),
+      radius: contextRadius,
       ring: "dashed",
       isSelected,
+      collisionRadius: collisionRadiusForLabel(node.label, contextRadius),
     }
   }
 
   const detailAngle =
     nodeDetailCount <= 1 ? 0 : (Math.PI * 1.45 * nodeDetailIndex) / Math.max(nodeDetailCount - 1, 1) - Math.PI * 0.72
 
-  const angle = nodeContextCount > 0 ? detailAngle : (Math.PI * 2 * index) / Math.max(count - 1, 1) - Math.PI / 2
+  const angle = detailLayout
+    ? Math.atan2(detailLayout.y - CENTER_Y, detailLayout.x - CENTER_X)
+    : nodeContextCount > 0
+      ? detailAngle
+      : (Math.PI * 2 * index) / Math.max(count - 1, 1) - Math.PI / 2
+
+  const x = detailLayout
+    ? detailLayout.x
+    : Math.round(CENTER_X + Math.cos(angle) * LAYOUT_RADIUS_X)
+  const y = detailLayout
+    ? detailLayout.y
+    : Math.round(CENTER_Y + Math.sin(angle) * LAYOUT_RADIUS_Y)
+  const radius = radiusForSourceType(node.type, false)
+
   return {
     id: node.id,
     label: node.label,
     kind: runeKindForSourceType(node.type),
-    x: Math.round(CENTER_X + Math.cos(angle) * LAYOUT_RADIUS_X),
-    y: Math.round(CENTER_Y + Math.sin(angle) * LAYOUT_RADIUS_Y),
-    radius: radiusForSourceType(node.type, false),
+    x: Math.round(x),
+    y: Math.round(y),
+    radius,
     ring: ringForSourceType(node.type),
     isSelected,
+    group: detailLayout?.group,
+    groupLabel: detailLayout?.groupLabel,
+    collisionRadius: collisionRadiusForLabel(node.label, radius),
   }
 }
 
@@ -228,7 +796,8 @@ function runeKindForSourceType(type: string): RuneKind {
   }
 }
 
-function edgeKindFor(source: SourceNode | undefined, target: SourceNode | undefined): EdgeKind {
+function edgeKindFor(link: SourceLink, source: SourceNode | undefined, target: SourceNode | undefined): EdgeKind {
+  if (link.kind === "imports") return "import"
   if (source?.type === "context" || target?.type === "context") return "context"
 
   switch (target?.type) {
@@ -240,7 +809,6 @@ function edgeKindFor(source: SourceNode | undefined, target: SourceNode | undefi
       return "data"
   }
 }
-
 
 function ringForSourceType(type: string): RuneNode["ring"] {
   switch (type) {
@@ -269,6 +837,10 @@ function radiusForSourceType(type: string, isFocus: boolean): number {
     default:
       return 40
   }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(value, max))
 }
 
 function emptySourceNode(): SourceNode {

--- a/web/src/types/source-graph.ts
+++ b/web/src/types/source-graph.ts
@@ -4,9 +4,12 @@ export interface SourceNode {
   type: string
 }
 
+export type SourceLinkKind = "contains" | "imports"
+
 export interface SourceLink {
   source: string
   target: string
+  kind?: SourceLinkKind
 }
 
 export interface SourceGraph {

--- a/web/src/types/spell-diagram.ts
+++ b/web/src/types/spell-diagram.ts
@@ -1,6 +1,6 @@
 export type RuneKind = "method" | "local" | "policy" | "async" | "response" | "error" | "context"
 
-export type EdgeKind = "data" | "error" | "response" | "context"
+export type EdgeKind = "data" | "error" | "response" | "context" | "import"
 
 export interface RuneNode {
   id: string
@@ -9,8 +9,11 @@ export interface RuneNode {
   x: number
   y: number
   radius: number
-  ring?: "solid" | "dashed" | "focus"
   isSelected?: boolean
+  ring?: "solid" | "dashed" | "focus"
+  collisionRadius?: number
+  group?: string
+  groupLabel?: string
 }
 
 export interface LeylineEdge {

--- a/web/src/views/HomeView.vue
+++ b/web/src/views/HomeView.vue
@@ -40,6 +40,7 @@ const selectedExampleId = ref<string | undefined>(persistedWorkspace?.exampleId)
 const selectedNodeId = ref<string | undefined>(persistedWorkspace?.selectedNodeId)
 const importStatus = ref<"idle" | "loading" | "success" | "error">(persistedWorkspace ? "success" : "idle")
 const importMessage = ref(persistedWorkspace?.message ?? defaultImportMessage)
+
 const isImporting = computed(() => importStatus.value === "loading")
 const graphNodeCount = computed(() => sourceGraph.value?.nodes.length ?? usersControllerIndexDiagram.nodes.length)
 const graphLinkCount = computed(() => sourceGraph.value?.links.length ?? usersControllerIndexDiagram.edges.length)
@@ -55,6 +56,34 @@ const currentDiagram = computed<SpellDiagram>(() => {
 })
 const selectedNode = computed(() => currentDiagram.value.nodes.find((node) => node.id === selectedNodeId.value))
 const selectedConnections = computed(() => connectedNodes(currentDiagram.value, selectedNode.value))
+const relatedGroups = computed(() => {
+  const groups = new Map<string, { id: string; label: string; count: number; representativeNodeId: string }>()
+
+  currentDiagram.value.nodes.forEach((node) => {
+    if (!node.group) return
+
+    const existing = groups.get(node.group)
+    if (existing) {
+      existing.count += 1
+      return
+    }
+
+    groups.set(node.group, {
+      id: node.group,
+      label: node.groupLabel?.trim() || `Related ${node.kind} group`,
+      count: 1,
+      representativeNodeId: node.id,
+    })
+  })
+
+  return [...groups.values()].sort((left, right) => right.count - left.count)
+})
+const relatedGroupsLabel = computed(() =>
+  relatedGroups.value.length
+    ? `${relatedGroups.value.length} relationship group${relatedGroups.value.length === 1 ? "" : "s"}`
+    : "No groups",
+)
+
 syncDocumentTitle(diagramTitle.value)
 
 function loadBuiltInSample(): void {
@@ -130,18 +159,17 @@ async function openNativeWorkspace(desktop: NonNullable<Window["dimensionDesktop
     setWorkspace({
       graph: workspace.graph,
       title: workspace.name,
-      subtitle: "Native workspace with local folder/file hierarchy.",
+      subtitle: "Native workspace with local folder hierarchy and JavaScript/TypeScript import relationships.",
       sourceName: workspace.name,
       sourceUrl: undefined,
       selectedNodeId: selectedId,
-      message: `Mapped ${firstLayerCount} first-layer item${firstLayerCount === 1 ? "" : "s"} from ${workspace.name}; the local workspace root stays in the desktop host.`,
+      message: `Mapped ${firstLayerCount} first-layer item${firstLayerCount === 1 ? "" : "s"} from ${workspace.name}; Dimension reads local JavaScript/TypeScript import declarations in the desktop host, and source files stay on this device.`,
     })
   } catch (error) {
     importStatus.value = "error"
     importMessage.value = error instanceof Error ? error.message : "Dimension could not open the selected folder."
   }
 }
-
 
 function selectNode(id: string): void {
   selectedNodeId.value = id
@@ -180,13 +208,13 @@ function persistCurrentWorkspace(): void {
 }
 
 function firstLayerNodeId(graph: SourceGraph): string | undefined {
-  return graph.nodes.find((node) => node.type === "class" || node.type === "folder")?.id ?? graph.nodes[0]?.id
+  return graph.nodes.find((node) => node.type === "class" || node.type === "file" || node.type === "folder")?.id ?? graph.nodes[0]?.id
 }
 
 function directChildCount(graph: SourceGraph, nodeId: string | undefined): number {
   if (!nodeId) return 0
 
-  return graph.links.filter((link) => link.source === nodeId).length
+  return graph.links.filter((link) => link.source === nodeId && link.kind !== "imports").length
 }
 
 function connectedNodes(diagram: SpellDiagram, node: RuneNode | undefined): RuneNode[] {
@@ -201,7 +229,6 @@ function connectedNodes(diagram: SpellDiagram, node: RuneNode | undefined): Rune
 
   return diagram.nodes.filter((candidate) => connectionIds.has(candidate.id))
 }
-
 
 function readPersistedWorkspace(): PersistedWorkspace | undefined {
   try {
@@ -325,6 +352,17 @@ function syncDocumentTitle(workspaceTitle: string): void {
           <dd>{{ graphLinkCount }}</dd>
         </div>
       </dl>
+      <section class="relationship-groups" aria-label="Relationship groups">
+        <p class="eyebrow">{{ relatedGroupsLabel }}</p>
+        <ul v-if="relatedGroups.length" class="relationship-groups__chips">
+          <li v-for="group in relatedGroups" :key="group.id">
+            <button type="button" :disabled="isImporting" @click="selectNode(group.representativeNodeId)">
+              {{ group.label }} ({{ group.count }})
+            </button>
+          </li>
+        </ul>
+        <p v-else class="relationship-groups__empty">No relationship groups are currently visible in this map.</p>
+      </section>
     </section>
 
     <section class="inspection-pane" aria-label="Dimension graph inspection">


### PR DESCRIPTION
## Related links

Fixes #49

## Context

A local workspace should remain a readable direct-child map while still exposing lightweight file relationships.

## Implementation

- Keep folder navigation to direct containment children.
- Detect local JavaScript/TypeScript import paths in the desktop host and render them as dashed orange relationships when a file is selected.
- Group related items, deduplicate graph elements, and settle layout collisions without reading symbolic-link targets.
- Ignore commented declarations and regular-expression text while extracting local relationships; multiline imports remain supported.

## Screenshots

N/A — the mounted browser device rejected QA startup with an unresolved virtual target; no screenshot was captured.

## Testing instructions

1. Run `./bin/dev up`, then `./bin/dev desktop`.
2. Open a local JavaScript/TypeScript project with a relative import.
3. Select an importing file. Its local import neighbors should appear with dashed orange lines; a folder selection should show direct children only.

## Review and QA evidence

- Scope review: PASS. PR #87 contains only relationship-map source/test files; existing #82 changes to `README.md`, `bin/dev`, and `docker-compose.development.yml` remain unstaged.
- Self-review: PASS. Fixed import visibility for selected files, dotted extensionless module resolution, symbolic-link scanning, comments, regular-expression text in import/export declarations, and multiline imports before this review.
- Automated: PASS — `node --test desktop/workspace.test.cjs` (6 tests) and `./bin/dev run web npm run build`.
- CI: BLOCKED — no GitHub Actions workflow run exists for `ae812f0`.
- User-visible QA: BLOCKED — the harness browser device could not open, so Electron interaction and a screenshot remain unobserved. The PR stays draft and must not merge until the manual desktop scenario above is observed.

## Learner coverage

No action — #49 is a user-directed feature request.